### PR TITLE
fix(brush): slove first select not effect problem. fix #1129

### DIFF
--- a/common/changes/@visactor/vchart/fix-brush-first-select_2023-10-24-07-45.json
+++ b/common/changes/@visactor/vchart/fix-brush-first-select_2023-10-24-07-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vchart",
+      "comment": "fix(brush): slove first select not effect problem. fix #1129",
+      "type": "none"
+    }
+  ],
+  "packageName": "@visactor/vchart"
+}

--- a/packages/vchart/src/component/brush/brush.ts
+++ b/packages/vchart/src/component/brush/brush.ts
@@ -58,7 +58,7 @@ export class Brush extends BaseComponent<IBrushSpec> implements IBrush {
   private _needInitOutState: boolean = true;
   private _cacheInteractiveRangeAttrs: BrushInteractiveRangeAttr[] = [];
 
-  private _needEnablePickable: boolean = true;
+  private _needEnablePickable: boolean = false;
 
   init() {
     const inBrushMarkAttr = this._transformBrushedMarkAttr(this._spec?.inBrush);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VChart/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Release
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 🔗 Related PR link

<!-- Put the related PR links here. -->

### 🐞 Bugserver case id
6523daed6fa8ab02e8bb7b6f&interactionid=653775d6998f7054b80e5f1e
<!-- paste the `fileid` field in the bugserver case url -->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
