### PR TITLE
fix: 标注更新问题修复

### DIFF
--- a/common/changes/@visactor/vchart/fix-marker-updateSpec_2024-05-14-09-12.json
+++ b/common/changes/@visactor/vchart/fix-marker-updateSpec_2024-05-14-09-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vchart",
+      "comment": "fix: when marker's spec update, it should update when call vchart.updateSpec",
+      "type": "none"
+    }
+  ],
+  "packageName": "@visactor/vchart"
+}

--- a/packages/vchart/src/component/marker/base-marker.ts
+++ b/packages/vchart/src/component/marker/base-marker.ts
@@ -1,7 +1,7 @@
 import { DataSet, DataView } from '@visactor/vdataset';
 import type { Maybe } from '@visactor/vutils';
 // eslint-disable-next-line no-duplicate-imports
-import { array, isValid, isNil, isString, isEmpty, isArray } from '@visactor/vutils';
+import { array, isValid, isNil, isString, isEmpty, isArray, isEqual } from '@visactor/vutils';
 import type { IModelRenderOption, IModelSpecInfo } from '../../model/interface';
 import type { IRegion } from '../../region/interface';
 import type { ICartesianSeries } from '../../series/interface';
@@ -341,5 +341,15 @@ export abstract class BaseMarker<T extends IMarkerSpec> extends BaseComponent<T>
       this._layoutOffsetY = calcLayoutNumber(this._spec.offsetY, chartViewRect.height, chartViewRect);
     }
     super.onLayoutStart(layoutRect, chartViewRect, ctx);
+  }
+
+  _compareSpec(spec: T, prevSpec: T) {
+    const result = super._compareSpec(spec, prevSpec);
+    if (!isEqual(prevSpec, spec)) {
+      result.reRender = true;
+      result.reMake = true;
+      result.change = true;
+    }
+    return result;
   }
 }

--- a/packages/vchart/src/component/marker/mark-line/base-mark-line.ts
+++ b/packages/vchart/src/component/marker/mark-line/base-mark-line.ts
@@ -115,7 +115,7 @@ export abstract class BaseMarkLine extends BaseMarker<IMarkLineSpec> implements 
     return markLine as unknown as IGroup;
   }
 
-  protected _markerLayout() {
+  protected _getUpdateMarkerAttrs() {
     const spec = this._spec;
     const data = this._markerData;
     const startRelativeSeries = this._startRelativeSeries;
@@ -150,13 +150,18 @@ export abstract class BaseMarkLine extends BaseMarker<IMarkLineSpec> implements 
         : markerComponentAttr.label?.text
     };
 
-    this._markerComponent?.setAttributes({
+    return {
       ...pointsAttr,
       label: labelAttrs as MarkLineComponent['attribute']['label'],
       limitRect,
       dx: this._layoutOffsetX,
       dy: this._layoutOffsetY
-    });
+    };
+  }
+
+  protected _markerLayout() {
+    const updateAttrs = this._getUpdateMarkerAttrs();
+    this._markerComponent?.setAttributes(updateAttrs);
   }
 
   protected _initDataView(): void {

--- a/packages/vchart/src/component/marker/mark-line/cartesian-mark-line.ts
+++ b/packages/vchart/src/component/marker/mark-line/cartesian-mark-line.ts
@@ -74,7 +74,6 @@ export class CartesianMarkLine extends BaseMarkLine {
   }
 
   protected _markerLayout() {
-    super._markerLayout();
     const spec = this._spec as any;
     const data = this._markerData;
     const startRelativeSeries = this._startRelativeSeries;

--- a/packages/vchart/src/component/marker/mark-line/cartesian-mark-line.ts
+++ b/packages/vchart/src/component/marker/mark-line/cartesian-mark-line.ts
@@ -74,41 +74,12 @@ export class CartesianMarkLine extends BaseMarkLine {
   }
 
   protected _markerLayout() {
-    const spec = this._spec as any;
-    const data = this._markerData;
-    const startRelativeSeries = this._startRelativeSeries;
-    const endRelativeSeries = this._endRelativeSeries;
-    const relativeSeries = this._relativeSeries;
-
-    const { points } = this._computePointsAttr();
-
-    const seriesData = this._relativeSeries.getViewData().latestData;
-    const dataPoints =
-      data.latestData[0] && data.latestData[0].latestData ? data.latestData[0].latestData : data.latestData;
-
-    let limitRect;
-    if (spec.clip || spec.label?.confine) {
-      const { minX, maxX, minY, maxY } = computeClipRange([
-        startRelativeSeries.getRegion(),
-        endRelativeSeries.getRegion(),
-        relativeSeries.getRegion()
-      ]);
-      limitRect = {
-        x: minX,
-        y: minY,
-        width: maxX - minX,
-        height: maxY - minY
-      };
-    }
-    const markerComponentAttr = this._markerComponent?.attribute ?? {};
-    const labelAttrs = {
-      ...markerComponentAttr.label,
-      text: this._spec.label.formatMethod
-        ? this._spec.label.formatMethod(dataPoints, seriesData)
-        : markerComponentAttr.label?.text
-    };
+    const updateAttrs = this._getUpdateMarkerAttrs();
 
     if ((this._spec as IStepMarkLineSpec).type === 'type-step') {
+      const startRelativeSeries = this._startRelativeSeries;
+      const endRelativeSeries = this._endRelativeSeries;
+
       const { multiSegment, mainSegmentIndex } = (this._spec as IStepMarkLineSpec).line || {};
       const { connectDirection, expandDistance = 0 } = this._spec as IStepMarkLineSpec;
 
@@ -141,6 +112,7 @@ export class CartesianMarkLine extends BaseMarkLine {
       } else {
         expandDistanceValue = expandDistance as number;
       }
+      const { points, label, limitRect } = updateAttrs;
 
       const joinPoints = getInsertPoints(
         (points as IPoint[])[0],
@@ -167,7 +139,7 @@ export class CartesianMarkLine extends BaseMarkLine {
           refY: 0
         };
       }
-
+      const markerComponentAttr = this._markerComponent?.attribute ?? {};
       this._markerComponent?.setAttributes({
         points: multiSegment
           ? [
@@ -177,7 +149,7 @@ export class CartesianMarkLine extends BaseMarkLine {
             ]
           : joinPoints,
         label: {
-          ...labelAttrs,
+          ...label,
           ...labelPositionAttrs,
           textStyle: {
             ...markerComponentAttr.label.textStyle,
@@ -192,13 +164,7 @@ export class CartesianMarkLine extends BaseMarkLine {
         dy: this._layoutOffsetY
       } as any);
     } else {
-      this._markerComponent?.setAttributes({
-        points,
-        label: labelAttrs as MarkLineComponent['attribute']['label'],
-        limitRect,
-        dx: this._layoutOffsetX,
-        dy: this._layoutOffsetY
-      } as any);
+      this._markerComponent?.setAttributes(updateAttrs);
     }
   }
 


### PR DESCRIPTION
1. CartesianMarkLine 类中的  _markLayout 是覆写 BaseMarkLine 基类的 _markLayout 方法，无需调用父类，一是这样会导致标注多次更新，二是导致在图表编辑器场景因为会有较频繁的图表更新操作，导致标注更新报错
2. 抽象公共方法，优化代码
3. 修复标注的更新逻辑

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Release
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Other (about what?)


### 🐞 Bugserver case id

66432b2e0b3b8900c63a7841

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
5. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
