### PR TITLE
feat(sequence-scatter-background): add categorical background drawing…

### DIFF
--- a/packages/vchart-extension/__tests__/runtime/browser/test-page/sequence-scatter.ts
+++ b/packages/vchart-extension/__tests__/runtime/browser/test-page/sequence-scatter.ts
@@ -1,31 +1,38 @@
 import { registerSequenceScatter } from '../../../../src';
 import { VChart } from '@visactor/vchart';
 import trainingData1 from '../data/sequence-scatter/Training_process1/data.json';
+import labelData from '../data/sequence-scatter/Training_process1/label.json';
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import trainingData2 from '../data/sequence-scatter/Training_process2/data.json';
+// import trainingData2 from '../data/sequence-scatter/Training_process2/data.json';
+// import labelData from '../data/sequence-scatter/Training_process2/label.json';
+
 const origianlData = trainingData1;
 // const origianlData = trainingData2;
 const chartData = {};
-Object.keys(origianlData).forEach(inter => {
-  chartData[inter] = [];
-  origianlData[inter].projection.forEach(pos => {
-    chartData[inter].push({
+Object.keys(origianlData).forEach(iter => {
+  chartData[iter] = [];
+  origianlData[iter].projection.forEach((pos, index) => {
+    chartData[iter].push({
       x: pos[0],
-      y: pos[1]
+      y: pos[1],
+      label: labelData.label_index[index]
     });
   });
 });
+
 const spec = {
   type: 'sequenceScatter',
   data: chartData,
   xField: 'x',
   yField: 'y',
+  seriesField: 'label',
 
   infoLabel: {
     visible: true,
     style: {
       text: datum => {
-        return 'interation: ' + datum.inter;
+        return 'iteration: ' + datum.iter;
       }
     }
   },

--- a/packages/vchart-extension/src/charts/sequence-scatter/sequence-scatter-transformer.ts
+++ b/packages/vchart-extension/src/charts/sequence-scatter/sequence-scatter-transformer.ts
@@ -4,6 +4,12 @@ import { CommonChartSpecTransformer } from '@visactor/vchart';
 
 const DATA_KEY = 'dataKey';
 
+interface Point {
+  x: number;
+  y: number;
+  label?: string;
+}
+
 export class SequenceScatterChartSpecTransformer extends CommonChartSpecTransformer<any> {
   transformSpec(spec: any): void {
     super.transformSpec(spec);
@@ -12,19 +18,128 @@ export class SequenceScatterChartSpecTransformer extends CommonChartSpecTransfor
     spec.type = 'common';
     spec.dataKey = DATA_KEY;
     spec.data = dataSpecs[0].data;
+
+    spec.scales = [
+      {
+        id: 'colorScale',
+        type: 'ordinal',
+        specified: {
+          '0': 'rgb(150, 10, 100)',
+          '1': 'rgb(31, 119, 180)',
+          '2': 'rgb(255, 127, 14)',
+          '3': 'rgb(44, 160, 44)',
+          '4': 'rgb(214, 39, 40)',
+          '5': 'rgb(148, 103, 189)',
+          '6': 'rgb(140, 86, 75)',
+          '7': 'rgb(227, 119, 194)',
+          '8': 'rgb(127, 127, 127)',
+          '9': 'rgb(188, 189, 34)',
+          '10': 'rgb(23, 190, 207)'
+        }
+      },
+      {
+        id: 'brighterColorScale',
+        type: 'ordinal',
+        specified: {
+          '0': 'rgb(150, 10, 150)',
+          '1': 'rgb(31, 119, 230)',
+          '2': 'rgb(255, 127, 64)',
+          '3': 'rgb(44, 160, 94)',
+          '4': 'rgb(214, 39, 90)',
+          '5': 'rgb(148, 103, 239)',
+          '6': 'rgb(140, 86, 125)',
+          '7': 'rgb(227, 119, 244)',
+          '8': 'rgb(127, 127, 177)',
+          '9': 'rgb(188, 189, 84)',
+          '10': 'rgb(23, 190, 255)'
+        }
+      }
+    ];
     spec.series = [
       {
         type: 'scatter',
-        xField: spec.xField,
-        yField: spec.yField
+        dataIndex: 0,
+        xField: 'x',
+        yField: 'y',
+        seriesField: 'label',
+        size: 5,
+        point: {
+          zIndex: 1000,
+          style: {
+            fill: {
+              scale: 'colorScale',
+              field: 'label'
+            }
+          }
+        }
       }
     ];
+    spec.width = 800;
+    spec.height = 500;
+
+    // 获取图元位置
+    const regionX = 54;
+    const regionY = 26;
+
+    spec.customMark = [
+      {
+        type: 'text',
+        dataIndex: 1,
+        style: {
+          text: (datum: Datum) => datum['iter'],
+          x: 10,
+          y: () => 10,
+          textBaseline: 'top',
+          textAlign: 'left',
+          fontSize: 25,
+          fontWeight: 'bolder',
+          fill: 'black',
+          fillOpacity: 0.2,
+          ...spec.infoLabel?.style
+        }
+      },
+      {
+        type: 'symbol',
+        dataIndex: 2,
+        style: {
+          symbolType: 'rect',
+          x: (datum: any, ctx: any) => {
+            // 获取region位置
+            // const regionStartPoint = ctx.chart.getAllRegions()[0].getLayoutStartPoint();
+            // const { x: regionX } = regionStartPoint;
+            // 获取图元位置
+            const valueToX = ctx.chart.getAllSeries()[0]._markAttributeContext.valueToX;
+            const markX = valueToX([datum.x]);
+            return regionX + markX;
+          },
+          y: (datum: any, ctx: any) => {
+            // const regionStartPoint = ctx.chart.getAllRegions()[0].getLayoutStartPoint();
+            // const { y: regionY } = regionStartPoint;
+            const valueToY = ctx.chart.getAllSeries()[0]._markAttributeContext.valueToY;
+            const markY = valueToY([datum.y]);
+            return markY + regionY;
+          },
+          size: 5,
+          fill: {
+            scale: 'brighterColorScale',
+            field: 'label'
+          },
+          fillOpacity: (datum: any) => datum.kde * 10
+        }
+      }
+    ];
+
+    spec.tooltip = {
+      visible: true,
+      fields: ['x', 'y', 'label']
+    };
 
     if (spec.player) {
       spec.player = {
         ...spec.player,
         specs: dataSpecs
       };
+
       spec.animationAppear = {
         duration: spec.player?.duration ?? 2000,
         easing: 'linear'
@@ -39,53 +154,16 @@ export class SequenceScatterChartSpecTransformer extends CommonChartSpecTransfor
     spec.axes = [
       {
         orient: 'left',
-        type: 'linear'
+        type: 'linear',
+        nice: true
       },
       {
         orient: 'bottom',
-        label: { visible: true },
-        type: 'linear'
+        type: 'linear',
+        nice: true,
+        label: { visible: true }
       }
     ];
-
-    spec.customMark = [
-      {
-        type: 'text',
-        dataIndex: 1,
-        style: {
-          text: (datum: Datum) => datum['inter'],
-          x: 50,
-          y: () => 10,
-          textBaseline: 'top',
-          textAlign: 'left',
-          fontSize: 100,
-          fontWeight: 'bolder',
-          fill: 'black',
-          fillOpacity: 0.2,
-          ...spec.infoLabel?.style
-        }
-      }
-      // TODO: draw polygon according to data
-      // {
-      //   type: 'polygon',
-      //   dataIndex: 1,
-      //   style: {
-      //     points: (datum: Datum) => {
-      //       return [
-      //         {
-      //           x: ,
-      //           y:
-      //         },
-      //         //....
-      //       ];
-      //     },
-      //   }
-      // }
-    ];
-
-    spec.tooltip = {
-      visible: false
-    };
 
     super.transformSpec(spec);
   }
@@ -93,30 +171,101 @@ export class SequenceScatterChartSpecTransformer extends CommonChartSpecTransfor
 
 export function processSequenceData(spec: ISequenceScatterSpec) {
   const result: any[] = [];
-  Object.keys(spec.data).forEach(inter => {
+  Object.keys(spec.data).forEach(iter => {
+    const currentData = spec.data[iter].map((d: Datum, i) => ({
+      ...(d as Point),
+      [DATA_KEY]: i
+    }));
+
+    const kdeResults = calculateKDE(currentData, 150);
     result.push({
       data: [
         {
           id: 'nodes',
-          values: spec.data[inter].map((d, i) => {
-            return { ...d, [DATA_KEY]: i };
-          })
+          values: currentData
         },
-        // TODO: edges data
-        // {
-        //   id: 'edges',
-        //   values: [....]
-        // },
         {
-          id: 'inter',
-          values: [
-            {
-              inter
-            }
-          ]
+          id: 'iter',
+          values: [{ iter }]
+        },
+        {
+          id: 'kde',
+          values: kdeResults
         }
       ]
     });
   });
   return result;
+}
+
+// KDE 相关的工具函数
+function gaussKernel(x: number) {
+  const SQRT2PI2 = Math.sqrt((Math.PI * 2) ** 2);
+  return Math.exp(-(x ** 2) / 2) / SQRT2PI2;
+}
+
+function scottBandwidth(data: Point[]) {
+  return data.length ** (-1 / 6);
+}
+function calculateKDE(data: Point[], bins = 100, bandwidth?: number) {
+  const groupedData: { [key: string]: Point[] } = data.reduce((groups, point) => {
+    const label = point.label;
+    groups[label] = groups[label] || [];
+    groups[label].push(point);
+    return groups;
+  }, {} as { [key: string]: Point[] });
+
+  const kdeResult: Array<{ x: number; y: number; kde: number; label: string }> = [];
+
+  const expandRatio = 0.2; // 扩展比例
+
+  Object.entries(groupedData).forEach(([label, points]) => {
+    const h = bandwidth || scottBandwidth(points);
+
+    const xValues = points.map(d => d.x);
+    const yValues = points.map(d => d.y);
+
+    const xMin = Math.min(...xValues);
+    const xMax = Math.max(...xValues);
+    const yMin = Math.min(...yValues);
+    const yMax = Math.max(...yValues);
+
+    const xExpand = (xMax - xMin) * expandRatio;
+    const yExpand = (yMax - yMin) * expandRatio;
+
+    const xExtent = { min: xMin - xExpand, max: xMax + xExpand };
+    const yExtent = { min: yMin - yExpand, max: yMax + yExpand };
+
+    const xStep = (xExtent.max - xExtent.min) / bins;
+    const yStep = (yExtent.max - yExtent.min) / bins;
+
+    const densities: number[] = []; // 用于存储每个点的 density
+    for (let i = 0; i < bins; i++) {
+      for (let j = 0; j < bins; j++) {
+        const x = xExtent.min + i * xStep;
+        const y = yExtent.min + j * yStep;
+        let density = 0;
+        for (const point of points) {
+          const distance = Math.sqrt((x - point.x) ** 2 + (y - point.y) ** 2);
+          density += gaussKernel(distance / h);
+        }
+        density = density / (points.length * h * h);
+        densities.push(density); // 先暂存 density 值
+        kdeResult.push({ x, y, kde: density, label }); // 同时也先存入 kdeResult
+      }
+    }
+
+    // // 归一化每个 label 的 KDE 密度值到 [0, 1] 范围内
+    // const maxDensity = Math.max(...densities);
+    // const minDensity = Math.min(...densities);
+    //
+    // // 归一化
+    // for (let i = 0; i < kdeResult.length; i++) {
+    //   if (kdeResult[i].label === label) {
+    //     kdeResult[i].kde = (kdeResult[i].kde - minDensity) / (maxDensity - minDensity);
+    //   }
+    // }
+  });
+
+  return kdeResult;
 }


### PR DESCRIPTION
…(in progress)

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VChart/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [x] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Release
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
https://github.com/VisActor/VChart/issues/3574
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 🔗 Related PR link

<!-- Put the related PR links here. -->

### 🐞 Bugserver case id

<!-- paste the `fileid` field in the bugserver case url -->

### 💡 Background and solution
1. 问题与场景：

初步实现分类背景绘制功能：为了展示机器学习聚类算法的效果，动态显示不同标签的数据点在不同迭代轮次的聚集程度。

2. 解决方案与实现：

创建了 SequenceScatterChartSpecTransformer 类，将特定的序列散点图配置转换为通用的 VChart 配置。

主要包括：
- 数据转换： processSequenceData 函数处理原始序列数据，转换为 VChart 可识别的格式。
- KDE密度估计： 使用核密度估计 (KDE) 方法计算数据点的密度，并通过 customMark 在散点图上叠加显示密度信息。密度信息通过 symbol 图元的透明度 (fillOpacity) 来体现，密度越高，透明度越低，视觉上越明显。
- 动画支持： 增加了对 player 配置的支持，实现序列数据的动画展示。

3. 效果展示
图 1 为训练集 1 的效果，图 2 为训练集 2 的效果
![training1](https://github.com/user-attachments/assets/0081fe6f-285e-4edc-a3a8-983c2fefa8f6)
![training2](https://github.com/user-attachments/assets/222e8a5f-fff2-4645-bd2e-2e3489aee485)

5. 未来改进方向

KDE 参数调优： 未来将增加手动调节 bandwidth 的选项（调节核密度估计的平滑程度，bandwith 越高，估计的结果越平滑。每个数据点的影响范围更大，会将更多的邻近点纳入考虑范围），允许用户对 KDE 结果进行更精细的控制。

归一化策略： KDE 密度值的归一化被临时注释，当前的密度值直接映射到透明度。虽然保留了不同 label 间 KDE 值的相对大小关系，但缺乏统一的密度范围，可能导致不同数据集间的密度视觉呈现不一致。需要探索更通用的策略（目前策略是为不同标签的数据统一生成 100*100 = 10000 个图元，因此比较聚集的点的背景显示不出透明度差异，如效果展示中的图 1的紫色分组）。

性能优化： 计划优化 calculateKDE 函数的计算过程，以提高大数据集下的性能。

自定义程度提升： 将提供更多的配置项，允许用户自定义 KDE 密度图的颜色、形状等属性，满足个性化的需求。


<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
