### PR TITLE
feat(bar chart): make barGapInGroup percentage based on actual barWidth

### DIFF
--- a/docs/assets/option/en/series/bar-style.md
+++ b/docs/assets/option/en/series/bar-style.md
@@ -28,7 +28,7 @@ Supported since `1.2.0` version, it is used to adjust the column spacing within 
 If the number of arrays in `barGapInGroup` is less than the number of grouping levels, the last value will be used for subsequent grouping spacing.
 
 - `number` type, representing pixel value
-- `string` type, percentage usage, such as '10%', this value is the bandWidth proportion of the scale corresponding to the last grouping field (because the columns are of equal width, the scale of the last layer of grouping is used)
+- `string` type, percentage usage, such as '10%', the value is the proportion of the actual column width (barWidth)
 
 #${prefix} barMinHeight(number)
 

--- a/docs/assets/option/zh/series/bar-style.md
+++ b/docs/assets/option/zh/series/bar-style.md
@@ -28,7 +28,7 @@
 如果 `barGapInGroup` 的数组个数小于分组层数，则后面的分组间距使用最后一个值。
 
 - `number` 类型，表示像素值
-- `string` 类型，百分比用法，如 '10%'，该值为对应最后一个分组字段对应的 scale 的 bandWidth 占比(因为柱子是等宽的，所以采用最后一层分组的 scale)
+- `string` 类型，百分比用法，如 '10%'，该值为对应实际柱子宽度（barWidth）的占比
 
 #${prefix} barMinHeight(number)
 

--- a/packages/vchart/src/series/bar/bar.ts
+++ b/packages/vchart/src/series/bar/bar.ts
@@ -753,6 +753,7 @@ export class BarSeries<T extends IBarSeriesSpec = IBarSeriesSpec> extends Cartes
     const depth = isNil(scaleDepth) ? depthFromSpec : Math.min(depthFromSpec, scaleDepth);
 
     const bandWidth = axisHelper.getBandwidth?.(depth - 1) ?? DefaultBandWidth;
+    const barWidth = this._getBarWidth(axisHelper, depth);
     const size = depth === depthFromSpec ? (this._barMark.getAttribute(sizeAttribute, datum) as number) : bandWidth;
 
     if (depth > 1 && isValid(this._spec.barGapInGroup)) {
@@ -767,7 +768,7 @@ export class BarSeries<T extends IBarSeriesSpec = IBarSeriesSpec> extends Cartes
         // const groupValues = this.getViewDataStatistics()?.latestData?.[groupField]?.values ?? [];
         const groupValues = axisHelper.getScale(index)?.domain() ?? [];
         const groupCount = groupValues.length;
-        const gap = getActualNumValue(barInGroup[index - 1] ?? last(barInGroup), bandWidth);
+        const gap = getActualNumValue(barInGroup[index - 1] ?? last(barInGroup), barWidth);
         const i = groupValues.indexOf(datum[groupField]);
         if (index === groupFields.length - 1) {
           totalWidth += groupCount * size + (groupCount - 1) * gap;

--- a/packages/vchart/src/series/bar/interface.ts
+++ b/packages/vchart/src/series/bar/interface.ts
@@ -103,7 +103,7 @@ export interface IBarSeriesSpec
    * 当存在多层分组时，可以使用数组来设置不同层级的间距，如 [10, '20%']，表示第一层分组的间距为 10px，第二层分组的间距为 '20%'。
    * 如果 barGapInGroup 的数组个数小于分组层数，则后面的分组间距使用最后一个值。
    * 1. number 类型，表示像素值
-   * 2. string 类型，百分比用法，如 '10%'，该值为对应最后一个分组字段对应的 scale 的 bandWidth 占比(因为柱子是等宽的，所以采用最后一层分组的 scale)
+   * 2. string 类型，百分比用法，如 '10%'，该值为对应实际柱子宽度（barWidth）的占比
    * @since 1.2.0
    */
   barGapInGroup?: number | string | (number | string)[];


### PR DESCRIPTION
### 🤔 This is a ...

- [✅] New feature
- [ ] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Release
- [✅] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

closed https://github.com/VisActor/VChart/issues/3660

### 🔗 Related PR link

### 🐞 Bugserver case id

### 💡 Background and solution

#### Background

在 VChart 的柱状图（Bar Chart）组件中，barGapInGroup 属性用于控制同一组内柱子之间的间距。这个属性支持绝对像素值和百分比值（如 '50%'）两种形式。在之前的实现中，当使用百分比值时，是基于 bandWidth（分配空间）计算的，而非基于柱子的实际宽度。
这带来了一个问题： barMaxWidth barMinWidth barWidth会导致barWidth≠bandWidth，柱子间距并不会随着实际柱宽的变化而等比例调整，导致视觉效果不一致。

#### solution

修改 _getPosition 方法中计算 gap 的逻辑，将百分比基准从 bandWidth 改为实际的 barWidth

修改前的效果：
![before](https://github.com/user-attachments/assets/fa0314d2-8db9-4fa7-a45d-8a758b2c8e71)

修改后的效果：
![after](https://github.com/user-attachments/assets/822204ac-42bb-4e5f-9c53-fa46e9598bd6)

### 📝 Changelog

会影响同一组内柱子之间的间距

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [✅] Doc is updated/provided or not needed
- [✅] Demo is updated/provided or not needed
- [✅] TypeScript definition is updated/provided or not needed
- [✅] Changelog is provided or not needed

---

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
