### PR TITLE
fix: add inverse crosshair when set axes inverse

### DIFF
--- a/common/changes/@visactor/vchart/fix-histogram-inverse_2025-06-04-11-12.json
+++ b/common/changes/@visactor/vchart/fix-histogram-inverse_2025-06-04-11-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vchart",
+      "comment": "fix: add inverse crosshair when set axes inverse",
+      "type": "none"
+    }
+  ],
+  "packageName": "@visactor/vchart"
+}

--- a/packages/vchart/src/component/crosshair/utils/cartesian.ts
+++ b/packages/vchart/src/component/crosshair/utils/cartesian.ts
@@ -17,6 +17,7 @@ import { getAxisLabelOffset } from '../../axis/util';
 import { isValid } from '@visactor/vutils';
 import type { IAxis, ILinearAxis } from '../../axis';
 import { getFormatFunction } from '../../util';
+import { ComponentTypeEnum } from '../../interface';
 
 export const layoutByValue = (
   stateByField: CrossHairStateByField,
@@ -63,7 +64,7 @@ export const layoutByValue = (
     if (newCacheInfo) {
       newCacheInfo._isCache = useCache;
     }
-    let bandSize;
+    let bandSize: number = 0;
     let offsetSize: number = 0;
 
     // 计算x轴和y轴的数据，只允许最多一对x和一对y
@@ -87,6 +88,10 @@ export const layoutByValue = (
               bandSize = Math.abs(
                 startX - (field === 'xField' ? series.dataToPositionX1(datum) : series.dataToPositionY1(datum))
               );
+              // cartesian 线性 axies 轴反向时需要同步反向
+              if (axis.getInverse() && axis.type === ComponentTypeEnum.cartesianLinearAxis) {
+                bandSize = -bandSize;
+              }
               value = `${datum[field1]} ~ ${datum[field2]}`;
             } else {
               bandSize = 1;
@@ -95,6 +100,7 @@ export const layoutByValue = (
           }
           niceLabelFormatter = (axis as ILinearAxis).niceLabelFormatter;
         }
+
         if (newCacheInfo && attributes.label?.visible && !useCache) {
           const labelOffset = getAxisLabelOffset(axis.getSpec());
           const axisOrient = axis.getOrient();


### PR DESCRIPTION
<!--
首先，感谢您参与代码贡献! 😄
为了提交新的功能或修改,请在主分支`main`分支上拉取开发分支 。
在提交PR 之前，请确认下面列到的一些内容
你的PR在核心成员review后，合并到主分支
谢谢！
-->

### 🤔 这个分支是...

- [ ] 新功能
- [x] Bug fix
- [ ] Ts 类型更新
- [ ] 打包优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 重构
- [ ] 依赖版本更新
- [ ] 代码优化
- [ ] 测试 case 更新
- [ ] 分支合并
- [ ] 发布
- [ ] 网站/文档更新
- [ ] demo 更新
- [ ] Workflow
- [ ] 其他 (具体是什么，请补充?)

### 🔗 相关 issue 链接

<!--
1. 相关的issue或者讨论，请贴在这里.
2. close #xxxx or fix #xxxx for instance.
-->

Fixed https://github.com/VisActor/VChart/issues/3973

### 🔗 相关的 PR 链接

<!-- 如果有关联的其他项目 PR，请贴在这里 -->

None

### 🐞 Bugserver 用例 id

<!-- 将 bugserver case 上的 `fileid` 字段值黏贴过来 -->

Badcase：

```ts
const spec = {
  type: 'histogram',
  xField: 'from',
  x2Field: 'to',
  yField: 'profit',
  seriesField: 'type',
  barPadding: 10,
  bar: {
    style: {
      stroke: 'white',
      lineWidth: 1
    }
  },
  axes: [
    {
      orient: 'bottom',
      inverse: true,
      nice: false,
      tick: {
        visible: true
      }
    }
  ],
  title: {
    text: 'Profit',
    textStyle: {
      align: 'center',
      height: 50,
      lineWidth: 3,
      fill: '#333',
      fontSize: 25,
      fontFamily: 'Times New Roman'
    }
  },
  tooltip: {
    visible: true,
    mark: {
      title: {
        key: 'title',
        value: 'profit'
      },
      content: [
        {
          key: datum => datum['from'] + '～' + datum['to'],
          value: datum => datum['profit']
        }
      ]
    }
  },
  data: [
    {
      name: 'data1',
      values: [
        {
          from: 0,
          to: 10,
          profit: 2,
          type: 'A'
        },
        {
          from: 10,
          to: 16,
          profit: 3,
          type: 'B'
        },
        {
          from: 16,
          to: 18,
          profit: 15,
          type: 'C'
        },
        {
          from: 18,
          to: 26,
          profit: 12,
          type: 'D'
        },
        {
          from: 26,
          to: 32,
          profit: 22,
          type: 'E'
        },
        {
          from: 32,
          to: 56,
          profit: 7,
          type: 'F'
        },
        {
          from: 56,
          to: 62,
          profit: 17,
          type: 'G'
        }
      ]
    }
  ]
}
const vchart = new VChart(spec, { dom: CONTAINER_ID });
vchart.renderSync();

// Just for the convenience of console debugging, DO NOT COPY!
window['vchart'] = vchart;
```

### 💡 问题的背景&解决方案

<!--
1. 描述问题和场景
2. 如果包含UI/交互相关的修改，请提供GIF或者截图
3. 提供如何解决问题的，如果是开发新的功能，请提供最终的API实现和使用案例
-->

直方图 axes 设置反向后, 由于 bandSize 设置了 Math.abs 导致 crossHair 没有正确渲染。对 `axis.getInverse() && axis.type === ComponentTypeEnum.cartesianLinearAxis` 进行反向处理。

### 📝 Changelog

<!--
描述用户侧的修改，并列出所有可能的新功能、修改、以及风险
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed the issue with crosshair rendering in the wrong direction after histogram axes are reversed |
| 🇨🇳 Chinese | 修复直方图 axes 反向后 crosshair 渲染方向错误问题 |

### ☑️ 自测

⚠️ 在提交 PR 之前，请检查一下内容. ⚠️

- [x] 文档提供了，或者更新，或者不需要
- [x] Demo 提供了，或者更新，或者不需要
- [x] Ts 类型定义提供了，或者更新，或者不需要
- [x] Changelog 提供了，或者不需要

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough