### PR TITLE
docs(.trae,common/changes): add Trae job docs and PR flow updates

### DIFF
--- a/.trae/documents/auto-flow.solo.md
+++ b/.trae/documents/auto-flow.solo.md
@@ -1,0 +1,34 @@
+# Auto Flow（串行编排）Solo 使用说明
+
+- 入口文件：`./.trae/jobs/auto-flow.md`
+- 流程：分支预检查 → 自动化测试 → Rush 变更日志 → 创建 PR
+
+## 参数
+- `baseBranch`：默认 `develop`
+- `lang`：`zh|en`，默认 `zh`
+- `labels`：默认 `[changelog, test]`
+- `topic`：可选；用于 PR 标题优化（未提供时用当前分支名）
+- `message`：可选；作为 PR body 摘要
+- `bumpType`：默认 `auto`
+- `notCommit`：默认 `true`
+- `head`：可选；未提供时自动推导当前分支
+
+## 前置
+- 若需自动创建 PR 或聚合 Issue 标题，请先设置 `GITHUB_TOKEN`（参考 `./.trae/github-token.local.md`）
+
+## 使用（Solo）
+- 在聊天中发起：“执行 Auto Flow（.trae/jobs/auto-flow.md）”，可附加：
+  - `topic: feature-legend`
+  - `message: 'docs: chore(trae): add auto-flow'`
+  - `mode: browser`（默认以浏览器创建 PR，输出可复制内容与 compare URL）
+  - （可选）`openBrowser: true`（自动打开浏览器）
+
+## 输出
+- `autotest_report`：`./.trae/jobs/autotest.report.local.md`
+- `rush_change_entries`：`common/changes/**`
+- `pr_url`：PR 链接（若已创建）
+
+## 人工检查
+- 单测后检查报告与覆盖率摘要
+- 变更日志后检查 `common/changes/**`
+- PR 前检查标题与正文信息；如需补充 body，请人工完善后再创建

--- a/.trae/documents/autotest.solo.md
+++ b/.trae/documents/autotest.solo.md
@@ -1,0 +1,60 @@
+# Autotest（差异驱动单元测试生成）Solo 使用说明
+
+- 入口文件：`./.trae/jobs/autotest.md`
+- 作用：根据 `develop...HEAD` 的代码差异，自动生成/更新测试用例与快照，并运行覆盖率与报告
+
+## 参数
+- `sinceBranch`：默认 `develop`
+- `project`：默认 `auto`（自动识别变更包）；可指定如 `@visactor/vchart`
+- `mode`：`full`（默认）
+- `noSnapshot`：是否跳过快照，默认 `false`
+- `onlyNew`：仅生成新的自动化区块，默认 `false`
+- `reportFormat`：`md|json`，默认 `md`
+- `applyManualOverrides`：应用人工覆写，默认 `true`
+- `replaceAutogen`：允许替换已有 `autogen:` 块，默认 `false`
+- `dryRun`：仅预览不写文件，默认 `false`
+- `preview`：是否预览模式，默认 `false`
+- `stopOnError`：遇错停止，默认 `true`
+- `focusChangedOnly`：仅聚焦变更，默认 `true`
+- `snapshotStrategy`：`combined`（默认）
+- `tempReportPath`：默认 `./.trae/jobs/autotest.report.local.md`
+- `mockDefaults`：默认 `time=fixed(2020-01-01T00:00:00Z)`、`random=seed(42)`
+
+## 使用（Solo）
+- 最简：在聊天中发起“执行 Autotest Job（.trae/jobs/autotest.md）”
+- 指定包：`project: '@visactor/vchart'`
+- 指定输出格式：`reportFormat: 'json'`
+
+## 输出
+- `test_files`：新增/更新的 `.test.ts`
+- `snapshots`：快照文件
+- `coverage_report`：覆盖率摘要
+- `manual_nodes`：需人工处理的用例占位
+- `temp_markdown_report`：临时报告（默认写入 `./.trae/jobs/autotest.report.local.md`）
+
+## 成功标准
+- `tests_generated_for_changed_exports`
+- `compile_without_errors`
+- `coverage_increase_or_maintained`
+
+## 人工覆写示例
+```yaml
+manual_overrides:
+  - target: packages/vchart/src/util/color.ts#parseColor
+    mocks:
+      date: fixed(2020-01-01T00:00:00Z)
+      random: seed(42)
+    inputs:
+      - { args: ['#ff0000'], desc: '基本路径' }
+      - { args: ['invalid'], desc: '异常路径' }
+    asserts:
+      - { expect: 'toEqual', value: { r: 255, g: 0, b: 0 } }
+```
+
+## 运行与诊断
+- 我会自动执行 `rush run -p <project> -s test` 与 `test-cov`
+- TypeScript 诊断与覆盖率结果会写入临时报告以便复核
+
+## 注意事项
+- 若差异范围为空，建议指定 `project` 以运行目标包测试
+- 对低覆盖模块，建议补充手动测试并复跑 Autotest 以提升覆盖率

--- a/.trae/documents/changelog-rush-smart.solo.md
+++ b/.trae/documents/changelog-rush-smart.solo.md
@@ -1,0 +1,24 @@
+# Changelog（Rush 智能变更日志）Solo 使用说明
+
+- 入口文件：`./.trae/jobs/changelog-rush-smart.md`
+- 作用：对齐并增强 `change-all.ts`，生成 Rush 变更条目（`common/changes/**`）
+
+## 参数
+- `sinceBranch`：默认 `develop`
+- `message`：可选；若为空自动生成富摘要
+- `bumpType`：`auto|major|minor|patch`，默认 `auto`
+- `notCommit`：是否跳过 `git commit`，默认 `true`
+- `githubToken`：可选，聚合 Issue 标题时需要
+
+## 使用（Solo）
+- 在聊天中发起：“执行 Changelog Job（.trae/jobs/changelog-rush-smart.md）”，可附加：
+  - `message: 'docs: chore(trae): add auto-flow'`
+  - `bumpType: patch`
+
+## 输出
+- `rush_change_entries`：新增的变更条目路径集合
+- `computed_bump_type`：自动判定的 bump 类型
+- `final_message`：最终用于 `rush change` 的消息
+
+## 人工检查
+- 复核 `common/changes/**` 的内容（包名、类型、comment），必要时重新执行并覆盖 `message/bumpType`

--- a/.trae/documents/create-branch.solo.md
+++ b/.trae/documents/create-branch.solo.md
@@ -1,0 +1,20 @@
+# Create Branch Job（Solo 使用说明）
+
+- 入口文件：`./.trae/jobs/create-branch.md`
+- 适用场景：需要在本地通过 Job 统一创建开发分支
+
+## 参数
+- `baseBranch`：默认 `develop`
+- `branchPrefix`：默认 `chore/trae`
+- `topic`：必填，主题描述（例如 `feature-legend`）
+- `useDateSuffix`：是否追加日期后缀，默认 `true`
+
+## 使用（Solo）
+- 在聊天中发起：“执行 Create Branch Job（.trae/jobs/create-branch.md）”，并传入：
+  - `topic: feature-legend`
+
+## 输出
+- `branch_name`：生成的分支名
+
+## 人工检查
+- 执行完成后：`git status` 确认当前分支与工作树状态

--- a/.trae/documents/pr-create.solo.md
+++ b/.trae/documents/pr-create.solo.md
@@ -1,0 +1,52 @@
+# PR 创建 Job（Solo 使用说明）
+
+- 入口文件：`./.trae/jobs/pr-create.md`
+- 作用：依据仓库 PR 模版生成正文并创建 PR
+
+## 参数
+- `base`：默认 `develop`
+- `head`：可选；未提供时自动推导当前分支
+- `title`：必填；PR 标题
+- `lang`：`zh|en`，默认 `zh`
+- `labels`：可选标签数组
+- `draft`：是否草稿，默认 `false`
+- `useGhCli`：是否使用 `gh` 创建，默认 `true`
+- `mode`：`auto|gh|rest|browser`（默认 `auto`，优先浏览器免安装）
+- `localBodyFile`：是否生成本地可复制正文文件（默认 `false`）
+- `openBrowser`：是否自动打开 compare URL（默认 `true`）
+- `commitBeforeCreate`：创建 PR 前是否自动提交未提交变更（默认 `false`）
+- `commitMessage`：自动提交的 commit 消息（默认 `chore: auto commit before pr`）
+- `commitAllowEmpty`：是否允许空提交（默认 `false`）
+- `pushAfterCommit`：提交后是否自动推送当前分支（默认 `true`）
+- `commitMessageStrategy`：提交信息生成策略（`auto|topic|manual`，默认 `auto`）
+  - `auto`：按变更内容自动判定类型（`docs|test|chore`）、作用域（包名或顶层目录），主题取 `message` 首行或自动摘要
+  - `topic`：主题优先使用 `title`/外层 `topic`
+  - `manual`：使用 `commitMessage`
+
+## 前置（登录/令牌）
+- 优先方案：使用 GitHub CLI（`gh`）并已登录 → 不需要额外令牌
+- 备选方案：无 `gh` 时提供 `GITHUB_TOKEN`（参见 `./.trae/github-token.local.md`）
+- 兜底方案：生成浏览器 compare URL，使用你浏览器的登录态手动创建 PR
+
+## 使用（Solo）
+- 在聊天中发起：“执行 PR Job（.trae/jobs/pr-create.md）”，并传：
+  - `title: '[Auto] feature-legend'`
+  - （可选）`head: chore/trae-feature-legend-20251222-1030`
+  - （可选）`mode: auto|gh|rest|browser`（默认 `auto`）
+  - （可选）`localBodyFile: true|false`（默认 `false`）
+  - （可选）`openBrowser: true|false`（默认 `true`）
+  - （可选）`commitBeforeCreate: true`、`commitMessage: 'chore: auto commit before pr'`、`pushAfterCommit: true`
+  - （可选）`commitMessageStrategy: auto`
+
+## 正文准备
+- 若 `message` 已包含摘要与关联信息，可直接作为 body
+- 若需要补充，请先人工完善 body 文本，再执行创建（不生成临时文件）
+
+## 输出
+- `pr_url`：创建的 PR 链接（`gh/rest`）
+- `compare_url`：浏览器 compare 页面（`browser`）
+- `generated_title`：建议标题（便于复制）
+- `generated_body_preview`：建议正文（便于复制）
+
+## 人工检查
+- 提交前检查标题、关联链接与 Changelog 摘要是否完整

--- a/.trae/jobs/auto-flow.md
+++ b/.trae/jobs/auto-flow.md
@@ -1,0 +1,74 @@
+---
+job: release-prep-pipeline
+intent: prepare-release
+version: v1
+domain: pipeline
+runner: trae-solo
+parameters:
+  baseBranch: develop
+  lang: zh
+  labels:
+    - changelog
+    - test
+  topic: ''
+  message: ''
+  bumpType: auto
+  notCommit: true
+  head: ''
+  mode: auto
+required_parameters: []
+outputs:
+  - autotest_report
+  - rush_change_entries
+  - pr_url
+success_criteria:
+  - flow_completed
+---
+
+# Auto Flow Job（分支→单测→变更日志→PR 串行编排）
+
+## 参数检查
+
+- 分支参数 `head` 可选：若未提供，将通过 `git rev-parse --abbrev-ref HEAD` 推导当前分支
+- 建议提供 `topic` 以优化 PR 标题；未提供时将回退为当前分支名
+
+## 步骤
+
+1. 分支预检查
+
+- 运行 `git rev-parse --abbrev-ref HEAD` 获取当前分支作为 `head`
+- 确认当前分支不是 `main`/`develop`，且工作树状态符合提交规范
+- 人工检查点：如不在开发分支，请先自行创建并切换到正确分支
+
+2. 运行差异驱动单测
+
+- 执行 Job：`.trae/jobs/autotest.md`
+- 传参：`sinceBranch={{baseBranch}}`（其余沿用默认）
+- 接收输出：`autotest_report=.trae/jobs/autotest.report.local.md`
+- 人工检查点：打开临时报告，确认新增/更新测试与覆盖率
+
+3. 生成 Rush 变更日志
+
+- 执行 Job：`.trae/jobs/changelog-rush-smart.md`
+- 传参：`sinceBranch={{baseBranch}}`、`message={{message}}`、`bumpType={{bumpType}}`、`notCommit={{notCommit}}`
+- 接收输出：`rush_change_entries`
+- 人工检查点：检查 `common/changes/**` 条目与摘要
+
+4. 创建 PR
+
+- 执行 Job：`.trae/jobs/pr-create.md`
+- 传参：
+  - `base={{baseBranch}}`
+  - `head={{head}}`
+  - `title='[Auto] {{topic || head}}'`
+  - `lang={{lang}}`
+  - `labels={{labels}}`
+  - `message={{message}}`（用于正文摘要）
+  - `bumpType={{bumpType}}`
+  - `mode={{mode}}`（auto 优先 gh → token → 浏览器 URL）
+- 接收输出：`pr_url`
+- 人工检查点：最终确认并提交
+
+5. 完成
+
+- 标记 `flow_completed`，返回 `autotest_report`、`rush_change_entries` 与 `pr_url`

--- a/.trae/jobs/changelog-rush-smart.md
+++ b/.trae/jobs/changelog-rush-smart.md
@@ -1,0 +1,82 @@
+---
+job: generate-rush-changes-smart
+intent: rush-change-smart
+version: v1
+domain: release
+runner: trae-solo
+parameters:
+  sinceBranch: develop
+  message: ''
+  bumpType: auto
+  notCommit: true
+  githubToken: ''
+required_parameters: []
+outputs:
+  - rush_change_entries
+  - computed_bump_type
+  - final_message
+success_criteria:
+  - rush_changes_generated
+  - commitlint_passed
+manual_overrides: []
+---
+
+# Changelog Job（智能 Rush 变更日志生成）
+
+## 参数检查
+
+- 无必填参数，均有默认值
+- 如需“关联 Issue 标题”自动聚合，请提供 `githubToken`
+
+## 步骤
+
+1. 采集差异与提交
+
+- 运行 `git diff --name-only {{sinceBranch}}...HEAD`，按文件路径映射到变更包
+- 运行 `git log --pretty=%H:::%s {{sinceBranch}}...HEAD`，收集提交主题
+
+2. 自动判定 bumpType（可被参数覆盖）
+
+- 规则：
+  - 含 `BREAKING CHANGE` 或 `!` → `major`
+  - 含 `feat` → `minor`
+  - 其余（`fix|perf|refactor|docs|chore|test`）→ `patch`
+- 若 `parameters.bumpType != auto`，则使用显式值
+- 将结果写入输出：`computed_bump_type`
+
+3. 构建富消息（可被参数覆盖）
+
+- 若 `parameters.message` 为空：
+  - 提取关键提交的主题（优先 `feat`/`fix`）形成“提交概览”
+  - 从提交中解析 `#<id>`，调用 GitHub API 读取 Issue 标题（需 `githubToken`），形成“关联 Issue”
+  - 构建最终消息：首行摘要 + 提交概览 + 关联 Issue + 影响包
+- 将最终消息写入输出：`final_message`
+
+4. 提交信息校验
+
+- 使用 `common/autoinstallers/lint/commitlint.config.js` 与本地 `commitlint` 执行校验
+- 命令：`echo "{{final_message}}" | commitlint --config common/autoinstallers/lint/commitlint.config.js`
+
+5. 生成 Rush 变更条目
+
+- 执行 `rush change --bulk --bump-type '{{computed_bump_type}}' --message '{{final_message}}'`
+- 输出文件位于 `common/changes/**`，收集为 `rush_change_entries`
+
+6. 可选提交
+
+- 若 `notCommit != true`：
+  - 运行 `git add --all`
+  - 运行 `git commit -m 'docs: update changlog of rush'`
+
+7. 人工检查点
+
+- 展示 `rush_change_entries`：路径、包名、bumpType、摘要
+- 如摘要需细化，编辑 `parameters.message` 或在二次执行中通过 `manual_overrides` 指定
+
+## manual_overrides 示例
+
+```yaml
+manual_overrides:
+  - bumpType: minor
+    message: 'feat(core): 新增交互缩放配置，修复事件抛出问题 (#123)'
+```

--- a/.trae/jobs/create-branch.md
+++ b/.trae/jobs/create-branch.md
@@ -1,0 +1,52 @@
+---
+job: create-dev-branch
+intent: gitflow-create-branch
+version: v1
+domain: git
+runner: trae-solo
+parameters:
+  baseBranch: develop
+  branchPrefix: chore/trae
+  topic: ''
+  useDateSuffix: true
+required_parameters:
+  - topic
+outputs:
+  - branch_name
+success_criteria:
+  - branch_created
+  - clean_working_tree
+---
+
+# Create Branch Job（创建开发分支）
+
+## 参数检查
+
+- 必填参数：`topic`
+- 若未提供：请在执行入口中补充 `topic`（示例：`topic: perf-legend-opt`），再继续后续步骤。
+
+## 步骤
+
+1. 同步基础分支
+
+- 运行 `git fetch --all --prune`
+- 运行 `git checkout {{baseBranch}} && git pull origin {{baseBranch}}`
+
+2. 生成分支名
+
+- 命名规则：`{{branchPrefix}}-{{topic}}-{{YYYYMMDD-HHMM}}`
+- 将生成的分支名写入输出：`branch_name`
+
+3. 创建分支
+
+- 运行 `git checkout -b {{branch_name}}`
+
+4. 人工检查点
+
+- 运行 `git status` 并确认：
+  - 当前分支为 `{{branch_name}}`
+  - 工作树干净或仅包含预期改动
+
+## 结果
+
+- 成功则输出 `branch_name`，并保证后续任务在该分支上执行。

--- a/.trae/jobs/pr-create.md
+++ b/.trae/jobs/pr-create.md
@@ -1,0 +1,167 @@
+---
+job: create-pr
+intent: github-pr
+version: v1
+domain: github
+runner: trae-solo
+parameters:
+  base: develop
+  head: ''
+  title: ''
+  lang: zh
+  labels: []
+  draft: false
+  useGhCli: true
+  mode: auto # auto|gh|rest|browser
+  localBodyFile: false
+  openBrowser: true
+  commitBeforeCreate: false
+  commitMessage: ''
+  commitAllowEmpty: false
+  pushAfterCommit: true
+  commitMessageStrategy: auto # auto|topic|manual
+required_parameters:
+  - title
+inputs:
+  autotestReport: .trae/jobs/autotest.report.local.md
+  rushChangesDir: common/changes
+  bumpType: ''
+  message: ''
+outputs:
+  - pr_url
+  - compare_url
+  - generated_title
+  - generated_body_preview
+success_criteria:
+  - pr_created
+---
+
+# PR Job（根据模版创建 Pull Request）
+
+## 参数检查
+
+- 必填参数：`title`
+- 分支参数 `head` 可选：若未提供，将在执行阶段通过 `git rev-parse --abbrev-ref HEAD` 推导当前分支
+
+## 步骤
+
+1. 提交未提交的变更并推送（可选）
+
+- 获取 `head`：若未提供，通过 `git rev-parse --abbrev-ref HEAD` 推导
+- 检查工作树：`git status --porcelain`
+- 若存在未提交变更且 `commitBeforeCreate == true`：
+  - 运行 `git add --all`
+  - 生成提交信息（按 `commitMessageStrategy`）：
+    - `auto`：
+      - 类型判定：包含 `docs/` → `docs`；包含 `__tests__`/`*.test.*` → `test`；否则 → `chore`
+      - 作用域：变更路径为 `packages/<name>/...` 时取 `<name>`；否则取顶层目录（如 `docs`、`tools`、`common`、`.trae`）
+      - 主题：若提供 `message` 则使用其首行摘要；否则生成 `sync changes before PR (<N> files)` 并附加关键作用域
+      - 结果示例：`chore(vchart,tools): sync changes before PR (5 files)`
+    - `topic`：使用 `title` 或外层 `topic` 作为主题，类型与作用域同上
+    - `manual`：使用显式 `commitMessage`
+  - 运行 `git commit {{#commitAllowEmpty}}--allow-empty{{/commitAllowEmpty}} -m "{{<auto_generated_message>}}"`
+  - 若 `pushAfterCommit == true`：运行 `git push -u origin {{head}}`
+- 人工检查点：
+  - 若存在未提交变更但未开启自动提交，请先人工完成提交与推送再继续创建 PR
+
+2. 选择 PR 模版
+
+- 当 `{{lang}} == zh`：使用 `.github/PULL_REQUEST_TEMPLATE/pr_cn.md`
+- 否则使用 `.github/PULL_REQUEST_TEMPLATE.md`
+
+3. 准备正文
+
+- 若已提供完整 `message`（摘要）与必要信息（关联链接等），可直接使用作为 PR body
+- 若需要补充人工内容：提示用户完善 body 文本后再继续（不生成临时文件）
+
+- 生成可复制内容：
+- `generated_title = [Auto] {{title || (topic || head)}}`
+- 生成完整 PR 正文预览（Markdown 代码块），基于 `.github/PULL_REQUEST_TEMPLATE/pr_cn.md` 自动填充：
+  - 勾选项：`{{branch_type_checks}}`（如：新功能、Workflow 等）
+  - 关联：`{{issue_links}}`、`{{related_pr_links}}`、`{{bugserver_ids}}`
+  - 背景与方案：`{{background_solution}}`（从 `message` 与上下文生成）
+  - Changelog 表：`{{changelog_en}}` 与 `{{changelog_zh}}`（解析 `common/changes/**`）
+  - 自测勾选项：`{{self_check_items}}`
+  - Summary 与 Walkthrough：`{{summary_text}}`、`{{walkthrough_text}}`（包含分支、模板来源、测试摘要）
+- 代码块示例结构：
+
+  ```markdown
+  ### 🤔 这个分支是...
+
+  - [x] 新功能
+  - [x] Workflow
+
+  ### 🔗 相关 issue 链接
+
+  {{issue_links}}
+
+  ### 🔗 相关的 PR 链接
+
+  {{related_pr_links}}
+
+  ### 🐞 Bugserver 用例 id
+
+  {{bugserver_ids}}
+
+  ### 💡 问题的背景&解决方案
+
+  {{background_solution}}
+
+  ### 📝 Changelog
+
+  | Language   | Changelog        |
+  | ---------- | ---------------- |
+  | 🇺🇸 English | {{changelog_en}} |
+  | 🇨🇳 Chinese | {{changelog_zh}} |
+
+  ### ☑️ 自测
+
+  {{self_check_items}}
+
+  ---
+
+  ### 🚀 Summary
+
+  {{summary_text}}
+
+  ### 🔍 Walkthrough
+
+  {{walkthrough_text}}
+  ```
+
+- 若 `localBodyFile=true`：以完整代码块形式写入 `./.trae/output/pr.body.local.md`（被忽略提交）
+
+4. 人工检查点
+
+- 若 body 需要补充，请人工完成后继续（不生成临时文件）
+
+5. 创建 PR
+
+- 模式选择：
+
+  - `auto`：优先使用 `gh`（若已安装并登录）；其次使用 `GITHUB_TOKEN` 的 REST；最后提供浏览器 URL 手动创建
+  - `gh`：使用 GitHub CLI 创建（需本机已登录）
+  - `rest`：使用 `GITHUB_TOKEN` 调用 REST API 创建
+  - `browser`：生成 compare URL，打开浏览器页面手动确认
+
+- 检测与执行：
+  - 若未提供 `head`：先运行 `git rev-parse --abbrev-ref HEAD` 以推导当前分支
+  - 检测 `gh`：`command -v gh` 成功则执行：
+    - `gh pr create --base {{base}} --title "{{title}}" --body "{{message}}" --head {{head}} {{#labels}}--label {{labels}}{{/labels}} {{#draft}}--draft{{/draft}}`
+  - 若无 `gh` 而存在 `GITHUB_TOKEN`：使用 REST API `POST /repos/{owner}/{repo}/pulls`，body 使用 `{{message}}`
+  - 否则生成 compare URL：
+    - `compare_url = https://github.com/VisActor/VChart/compare/{{base}}...{{head}}?expand=1`
+    - 输出 `generated_title` 与以完整 Markdown 代码块格式的 `generated_body_preview`，便于直接复制到 PR 页面；若 `openBrowser=true` 在 macOS 运行 `open {{compare_url}}`
+
+6. 结果
+
+- 返回 `pr_url`，并在成功标准中标记为 `pr_created`
+- 在 `browser` 模式：返回 `compare_url`、`generated_title` 与完整的 `generated_body_preview`
+  （其中 `generated_body_preview` 为包含所有模板栏目且已自动填充的 Markdown 代码块）
+
+## 额外提示
+
+- 自动创建 PR 有三种方式：
+  - 本机已登录 `gh`：无需额外令牌（SSH 仅用于 git 操作，API 权限由 `gh` 登录提供）
+  - 本机无 `gh`：提供 `GITHUB_TOKEN` 用 REST API 创建
+  - 两者都不可用：生成 compare URL，使用浏览器登录后手动创建

--- a/common/changes/@visactor/vchart/feat-add-auto-flow-in-trae_2025-12-23-06-19.json
+++ b/common/changes/@visactor/vchart/feat-add-auto-flow-in-trae_2025-12-23-06-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "docs: chore(trae): add Trae jobs: auto-flow, smart changelog, PR pipeline",
+      "type": "patch",
+      "packageName": "@visactor/vchart"
+    }
+  ],
+  "packageName": "@visactor/vchart",
+  "email": "lixuef1313@163.com"
+}


### PR DESCRIPTION
### 🤔 这个分支是...

- [x] 新功能
- [ ] Bug fix
- [ ] Ts 类型更新
- [ ] 打包优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 重构
- [ ] 依赖版本更新
- [ ] 代码优化
- [ ] 测试 case 更新
- [ ] 分支合并
- [ ] 发布
- [ ] 网站/文档更新
- [ ] demo 更新
- [x] Workflow
- [ ] 其他 (具体是什么，请补充?)

### 🔗 相关 issue 链接

- 暂无（将根据评审反馈补充）

### 🔗 相关的 PR 链接

- 暂无

### 🐞 Bugserver 用例 id

- 暂无

### 💡 问题的背景&解决方案

- 背景：为提升团队在 Trae IDE 中的自动化效率，新增 Job 流水线支持，包括自动化流程执行（auto-flow）、智能 Changelog 聚合以及 PR 创建流水线。
- 方案：
  - 在 `.trae/jobs` 下新增 PR 创建 Job（支持 `auto/gh/rest/browser` 模式）
  - 自动生成标题与“完整正文”预览，结合 `common/changes/**` 与本地测试报告
  - 工作树干净时自动推送分支，保证 PR 可创建

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | chore(trae): add Trae jobs: auto-flow, smart changelog, PR pipeline |
| 🇨🇳 Chinese | chore(trae): 新增 Trae 任务：自动流程、智能变更日志、PR 管线 |

来源：`common/changes/@visactor/vchart/feat-add-auto-flow-in-trae_2025-12-23-06-19.json`

### ☑️ 自测

- [x] 文档提供了，或者更新，或者不需要
- [x] Demo 提供了，或者更新，或者不需要
- [x] Ts 类型定义提供了，或者更新，或者不需要
- [x] Changelog 提供了，或者不需要

---

### 🚀 Summary

- 实现 Trae 自动流程与 PR 管线，支持多模式创建 PR，自动聚合变更与测试摘要。

### 🔍 Walkthrough

- 基于分支 `feat/add-auto-flow-in-trae` 创建 PR 到 `develop`
- 模版来源：`.github/PULL_REQUEST_TEMPLATE/pr_cn.md`
- 变更摘要：`common/changes/@visactor/vchart/feat-add-auto-flow-in-trae_2025-12-23-06-19.json`
- 自动测试报告：`.trae/jobs/autotest.report.local.md`
  - 测试套件：36 通过 / 36 总数
  - 测试用例：109 通过 / 109 总数