### PR TITLE
fix(vchart): Support functional alternateColor in axis grid configuration

### DIFF
--- a/packages/vchart/src/component/axis/base-axis.ts
+++ b/packages/vchart/src/component/axis/base-axis.ts
@@ -11,9 +11,7 @@ import type {
   Datum,
   StringOrNumber,
   IGroup as ISeriesGroup,
-  CoordinateType,
-  IRect,
-  ILayoutRect
+  CoordinateType
 } from '../../typings';
 import { BaseComponent } from '../base/base-component';
 import { CompilableData } from '../../compile/data';
@@ -57,6 +55,7 @@ import { getFormatFunction } from '../util';
 import type { IComponentMark } from '../../mark/interface/mark';
 import type { ICompilableMark } from '../../compile/mark';
 import type { ICompilableData } from './../../compile/data/interface';
+import { transformFunctionAttribute } from '../../util/spec/transform';
 
 export abstract class AxisComponent<T extends ICommonAxisSpec & Record<string, any> = any> // FIXME: 补充公共类型，去掉 Record<string, any>
   extends BaseComponent<T>
@@ -654,7 +653,7 @@ export abstract class AxisComponent<T extends ICommonAxisSpec & Record<string, a
   protected _getGridAttributes() {
     const spec = this._spec;
     return {
-      alternateColor: spec.grid.alternateColor,
+      alternateColor: transformFunctionAttribute(spec.grid.alternateColor),
       alignWithLabel: spec.grid.alignWithLabel,
       style: isFunction(spec.grid.style)
         ? (datum: Datum, index: number) => {
@@ -668,7 +667,7 @@ export abstract class AxisComponent<T extends ICommonAxisSpec & Record<string, a
           : {
               type: 'line',
               visible: spec.subGrid.visible,
-              alternateColor: spec.subGrid.alternateColor,
+              alternateColor: transformFunctionAttribute(spec.subGrid.alternateColor),
               style: transformToGraphic(spec.subGrid.style)
             }
     };

--- a/packages/vchart/src/util/spec/transform.ts
+++ b/packages/vchart/src/util/spec/transform.ts
@@ -1,4 +1,4 @@
-import { isArray, isPlainObject, isString } from '@visactor/vutils';
+import { isArray, isFunction, isPlainObject, isString } from '@visactor/vutils';
 import type { ISeriesSpec } from '../../typings';
 
 // todo 以目前的场景来看，并没有递归的需要。
@@ -65,4 +65,11 @@ export function functionTransform(spec: ISeriesSpec, VChart: any): any {
     return (spec as ISeriesSpec[]).map((s: ISeriesSpec) => functionTransform(s, VChart));
   }
   return spec;
+}
+
+export function transformFunctionAttribute(att: unknown, ...args: unknown[]) {
+  if (isFunction(att)) {
+    return att(...args);
+  }
+  return att;
 }


### PR DESCRIPTION
<!--
首先，感谢您参与代码贡献! 😄
为了提交新的功能或修改,请在主分支`main`分支上拉取开发分支 。
在提交PR 之前，请确认下面列到的一些内容
你的PR在核心成员review后，合并到主分支
谢谢！
-->

### 🤔 这个分支是...

- [ ] 新功能
- [x] Bug fix
- [ ] Ts 类型更新
- [ ] 打包优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 重构
- [ ] 依赖版本更新
- [ ] 代码优化
- [ ] 测试 case 更新
- [ ] 分支合并
- [ ] 发布
- [ ] 网站/文档更新
- [ ] demo 更新
- [ ] Workflow
- [ ] 其他 (具体是什么，请补充?)

### 🔗 相关 issue 链接

<!--
1. 相关的issue或者讨论，请贴在这里.
2. close #xxxx or fix #xxxx for instance.
-->

### 🔗 相关的 PR 链接

<!-- 如果有关联的其他项目 PR，请贴在这里 -->

### 🐞 Bugserver 用例 id

<!-- 将 bugserver case 上的 `fileid` 字段值黏贴过来 -->

### 💡 问题的背景&解决方案

<!--
1. 描述问题和场景
2. 如果包含UI/交互相关的修改，请提供GIF或者截图
3. 提供如何解决问题的，如果是开发新的功能，请提供最终的API实现和使用案例
-->

Support functional `alternateColor` in axis grid configuration. Previously, `alternateColor` might not have been correctly evaluated if it was a function. This change ensures `transformFunctionAttribute` is used to resolve `alternateColor` for both grid and subGrid.

### 📝 Changelog

<!--
描述用户侧的修改，并列出所有可能的新功能、修改、以及风险
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Support functional `alternateColor` in axis grid configuration. |
| 🇨🇳 Chinese | 支持轴网格线配置中的 `alternateColor` 属性为函数类型。 |

### ☑️ 自测

⚠️ 在提交 PR 之前，请检查一下内容. ⚠️

- [ ] 文档提供了，或者更新，或者不需要
- [ ] Demo 提供了，或者更新，或者不需要
- [ ] Ts 类型定义提供了，或者更新，或者不需要
- [ ] Changelog 提供了，或者不需要

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
