### PR TITLE
Feat: boxplot linear x-axis

### DIFF
--- a/packages/vchart/src/series/box-plot/box-plot.ts
+++ b/packages/vchart/src/series/box-plot/box-plot.ts
@@ -350,7 +350,7 @@ export class BoxPlotSeries<T extends IBoxPlotSeriesSpec = IBoxPlotSeriesSpec> ex
     //获取自适应的图元宽度
     const bandAxisHelper = this._direction === Direction.horizontal ? this._yAxisHelper : this._xAxisHelper;
     const depthFromSpec = this._groups ? this._groups.fields.length : 1;
-    const bandWidth = bandAxisHelper.getBandwidth?.(depthFromSpec - 1);
+    const bandWidth = bandAxisHelper.getBandwidth?.(depthFromSpec - 1) ?? this._boxWidth;
 
     let width = bandWidth;
     if (isValid(this._spec.boxWidth)) {
@@ -386,7 +386,7 @@ export class BoxPlotSeries<T extends IBoxPlotSeriesSpec = IBoxPlotSeriesSpec> ex
     const depthFromSpec = this._groups ? this._groups.fields.length : 1;
     const depth = depthFromSpec;
 
-    const bandWidth = axisHelper.getBandwidth?.(depth - 1);
+    const bandWidth = axisHelper.getBandwidth?.(depth - 1) ?? this._boxWidth;
     const size = this._boxPlotMark.getAttribute(sizeAttribute, datum) as number;
 
     if (depth > 1 && isValid(this._spec.boxGapInGroup)) {
@@ -412,7 +412,7 @@ export class BoxPlotSeries<T extends IBoxPlotSeriesSpec = IBoxPlotSeriesSpec> ex
         }
       }
 
-      const center = scale.scale(datum[groupFields[0]]) + axisHelper.getBandwidth(0) / 2;
+      const center = scale.scale(datum[groupFields[0]]) + (axisHelper.getBandwidth(0) ?? this._boxWidth) / 2;
       return center - totalWidth / 2 + offSet + size / 2;
     }
 

--- a/packages/vchart/src/series/box-plot/box-plot.ts
+++ b/packages/vchart/src/series/box-plot/box-plot.ts
@@ -350,7 +350,7 @@ export class BoxPlotSeries<T extends IBoxPlotSeriesSpec = IBoxPlotSeriesSpec> ex
     //获取自适应的图元宽度
     const bandAxisHelper = this._direction === Direction.horizontal ? this._yAxisHelper : this._xAxisHelper;
     const depthFromSpec = this._groups ? this._groups.fields.length : 1;
-    const bandWidth = bandAxisHelper.getBandwidth?.(depthFromSpec - 1) ?? this._boxWidth;
+    const bandWidth = bandAxisHelper.getBandwidth?.(depthFromSpec - 1) ?? Math.max(this._boxWidth, this._shaftWidth);
 
     let width = bandWidth;
     if (isValid(this._spec.boxWidth)) {
@@ -386,7 +386,7 @@ export class BoxPlotSeries<T extends IBoxPlotSeriesSpec = IBoxPlotSeriesSpec> ex
     const depthFromSpec = this._groups ? this._groups.fields.length : 1;
     const depth = depthFromSpec;
 
-    const bandWidth = axisHelper.getBandwidth?.(depth - 1) ?? this._boxWidth;
+    const bandWidth = axisHelper.getBandwidth?.(depth - 1) ?? Math.max(this._boxWidth, this._shaftWidth);
     const size = this._boxPlotMark.getAttribute(sizeAttribute, datum) as number;
 
     if (depth > 1 && isValid(this._spec.boxGapInGroup)) {
@@ -412,7 +412,9 @@ export class BoxPlotSeries<T extends IBoxPlotSeriesSpec = IBoxPlotSeriesSpec> ex
         }
       }
 
-      const center = scale.scale(datum[groupFields[0]]) + (axisHelper.getBandwidth(0) ?? this._boxWidth) / 2;
+      const center =
+        scale.scale(datum[groupFields[0]]) +
+        (axisHelper.getBandwidth(0) ?? Math.max(this._boxWidth, this._shaftWidth)) / 2;
       return center - totalWidth / 2 + offSet + size / 2;
     }
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VChart/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Release
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link
close #4544 
<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 🔗 Related PR link


<!-- Put the related PR links here. -->

### 🐞 Bugserver case id

<!-- paste the `fileid` field in the bugserver case url -->

### 💡 Background and solution

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list the final API implementation and usage sample if that is a new feature.
-->
box-plot chart没有兼容x轴为linear-axis的情况，在计算mark位置和宽度时由于拿不到bandWidth导致无法计算。
若用户指定了boxWidth、shaftWidth，则选择其中的最大者作为bandWidth参与计算
测试spec：

```
 const data = [
    {
      name: 'boxPlot',
      values: [
        {
          x: '0',
          y1: 9.16270124,
          y2: 10.07530816,
          y3: 10.09027907,
          y4: 10.27579542,
          y5: 11.62222959,
          group: 'High income'
        },
        {
          x: '1',
          y1: 8.721525214,
          y2: 9.641352839,
          y3: 10.1736233,
          y4: 10.57169914,
          y5: 11.64427467,
          group: 'Low income'
        },
        {
          x: '2',
          y1: 9.404757278,
          y2: 10.36482449,
          y3: 10.94903493,
          y4: 11.5806383,
          y5: 12.50192084,
          group: 'Low income'
        },
        {
          x: '3',
          y1: 9.732841997,
          y2: 9.732841997,
          y3: 9.732841997,
          y4: 9.732841997,
          y5: 9.732841997,
          group: 'High income'
        },
        {
          x: '4',
          y1: 9.541951901,
          y2: 10.33719892,
          y3: 10.91206173,
          y4: 11.29821858,
          y5: 11.60653481,
          group: 'Low income'
        },
        {
          x: '5',
          y1: 10.2396509,
          y2: 10.63879995,
          y3: 11.09996104,
          y4: 11.54301107,
          y5: 11.92092709,
          group: 'High income'
        },
        {
          x: '6',
          y1: 10.14653181,
          y2: 10.32106777,
          y3: 10.45467215,
          y4: 10.45844052,
          y5: 10.6064696,
          group: 'Low income'
        },
        {
          x: '7',
          y1: 8.743652009,
          y2: 9.413881158,
          y3: 10.16606248,
          y4: 11.00011805,
          y5: 12.20655104,
          group: 'High income'
        },
        {
          x: '8',
          y1: 7.800035977,
          y2: 8.850646235,
          y3: 10.14633178,
          y4: 11.59877618,
          y5: 13.24880824,
          group: 'High income'
        },
        {
          x: '9',
          y1: 8.316035904,
          y2: 9.038602613,
          y3: 10.22954548,
          y4: 10.71782871,
          y5: 12.07411874,
          group: 'Low income'
        },
        {
          x: '10',
          y1: 9.831631935,
          y2: 9.939275167,
          y3: 10.39108655,
          y4: 10.95556656,
          y5: 11.3012157,
          group: 'Low income'
        },
        {
          x: '11',
          y1: 9.522480948,
          y2: 10.43085982,
          y3: 11.06642694,
          y4: 11.73822523,
          y5: 12.62940296,
          group: 'High income'
        }
      ]
    }
  ];

  const spec = {
    type: 'boxPlot',
    data: data,
    xField: ['x', 'group'],

    minField: 'y1',
    q1Field: 'y2',
    medianField: 'y3',
    q3Field: 'y4',
    maxField: 'y5',
    seriesField: 'group',

    direction: 'vertical',
    color: ['#BBD6B8', '#EA5455'],

    legends: [{ visible: true }],

    title: {
      visible: true,
      text: 'Global GDP 2021'
    },
    axes: [
      {
        type: 'linear',
        orient: 'bottom'
      }
    ],

    boxPlot: {
      style: {
        boxWidth: 50,
        shaftWidth: 30,
        shaftShape: 'bar',
        lineWidth: 2,
        shaftOpacity: 0.3
      }
    }
  };
```
<img width="2111" height="1168" alt="image" src="https://github.com/user-attachments/assets/ff8c8b8b-90df-48bf-b9e8-5d48841ec753" />


### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
