### PR TITLE
feat: add ExtensionMarkSyncStatePlugin for vchart-extension

### DIFF
--- a/common/changes/@visactor/vchart-extension/feat-extension-mark-sync-state_20260410.json
+++ b/common/changes/@visactor/vchart-extension/feat-extension-mark-sync-state_20260410.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vchart-extension",
+      "comment": "feat: add ExtensionMarkSyncStatePlugin to synchronize interactive states of extensionMark with primary marks",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@visactor/vchart-extension",
+  "email": "kitee0325@gmail.com"
+}

--- a/docs/assets/guide/en/tutorial_docs/Chart_Extensions/extension_mark_sync_state.md
+++ b/docs/assets/guide/en/tutorial_docs/Chart_Extensions/extension_mark_sync_state.md
@@ -1,0 +1,149 @@
+# ExtensionMark SyncState Plugin
+
+When using `extensionMark` to draw custom graphics on a series, these graphics do not follow the interactive states (hover, select, etc.) of the primary marks (bars, dots, etc.) by default.
+
+The `ExtensionMarkSyncStatePlugin` enables extensionMarks configured with `syncState: true` to automatically synchronize the interactive states of the corresponding primary marks, providing consistent visual feedback during interaction.
+
+## How It Works
+
+After each render, the plugin pairs extensionMark graphic elements with primary mark graphic elements via `context.key` (the data dimension identifier). When a primary mark's graphic changes state (e.g., highlight, blur, select), the corresponding extensionMark graphic automatically adopts the same state.
+
+> Note: State synchronization only works when the extension mark and the primary mark are bound to the same datum (i.e., they share the same `context.key`).
+
+## Registration
+
+```js
+import { registerExtensionMarkSyncStatePlugin } from '@visactor/vchart-extension';
+
+// Register before creating VChart instances
+registerExtensionMarkSyncStatePlugin();
+```
+
+When using the CDN global variable `VChartExtension`, call `VChartExtension.registerExtensionMarkSyncStatePlugin()`.
+
+## Usage
+
+Add `syncState: true` to the extensionMark configuration, along with the corresponding `state` styles:
+
+```javascript livedemo
+/** --Add the following code when used in business-- */
+// When using in a business context, install @visactor/vchart-extension separately (keep version consistent with vchart)
+// import { registerExtensionMarkSyncStatePlugin } from '@visactor/vchart-extension';
+/** --Add the above code when used in business-- */
+
+/** --Delete the following code when used in business-- */
+const { registerExtensionMarkSyncStatePlugin } = VChartExtension;
+/** --Delete the above code when used in business-- */
+
+registerExtensionMarkSyncStatePlugin();
+
+const data = [
+  { category: 'A', value: 80, group: 'February' },
+  { category: 'B', value: 120, group: 'February' },
+  { category: 'C', value: 60, group: 'February' },
+  { category: 'D', value: 150, group: 'February' },
+  { category: 'A', value: 90, group: 'March' },
+  { category: 'B', value: 100, group: 'March' },
+  { category: 'C', value: 110, group: 'March' },
+  { category: 'D', value: 70, group: 'March' }
+];
+
+const spec = {
+  type: 'bar',
+  data: [{ id: 'barData', values: data }],
+  xField: 'category',
+  yField: 'value',
+  seriesField: 'group',
+  bar: {
+    state: {
+      highlight: { stroke: '#000', lineWidth: 2 },
+      blur: { fillOpacity: 0.2 },
+      selected: { stroke: 'red', lineWidth: 3 }
+    }
+  },
+  extensionMark: [
+    {
+      type: 'symbol',
+      dataId: 'barData',
+      name: 'topDot',
+      syncState: true,
+      style: {
+        fill: datum => (datum.group === 'February' ? '#1664FF' : '#1AC6FF'),
+        symbolType: 'circle',
+        size: 12,
+        x: (datum, ctx) =>
+          ctx.valueToX([datum.category]) + ctx.xBandwidth() / 4 + (datum.group === 'March' ? ctx.xBandwidth() / 2 : 0),
+        y: (datum, ctx) => ctx.valueToY([datum.value]) - 15
+      },
+      state: {
+        highlight: { fill: 'orange', size: 20, stroke: '#000', lineWidth: 2 },
+        blur: { fillOpacity: 0.15, size: 8 },
+        selected: {
+          fill: 'red',
+          size: 22,
+          outerBorder: { distance: 3, lineWidth: 2, stroke: 'red' }
+        }
+      }
+    },
+    {
+      type: 'text',
+      dataId: 'barData',
+      name: 'topLabel',
+      syncState: true,
+      style: {
+        text: datum => `${datum.value}`,
+        fontSize: 11,
+        fill: '#333',
+        textAlign: 'center',
+        textBaseline: 'bottom',
+        x: (datum, ctx) =>
+          ctx.valueToX([datum.category]) + ctx.xBandwidth() / 4 + (datum.group === 'March' ? ctx.xBandwidth() / 2 : 0),
+        y: (datum, ctx) => ctx.valueToY([datum.value]) - 26
+      },
+      state: {
+        highlight: { fill: 'orange', fontSize: 16, fontWeight: 'bold' },
+        blur: { fillOpacity: 0.1 },
+        selected: { fill: 'red', fontSize: 14, fontWeight: 'bold' }
+      }
+    }
+  ],
+  interaction: {
+    hover: { enable: true },
+    select: { enable: true }
+  },
+  legends: { visible: true, orient: 'top' },
+  title: {
+    visible: true,
+    text: 'extensionMark syncState Plugin Demo',
+    subtext: 'Hover / Click bars to see state synchronization'
+  }
+};
+
+const vchart = new VChart(spec, { dom: CONTAINER_ID });
+vchart.renderSync();
+
+// Just for the convenience of console debugging, DO NOT COPY!
+window['vchart'] = vchart;
+```
+
+## API
+
+### registerExtensionMarkSyncStatePlugin()
+
+Registers the ExtensionMark SyncState plugin. Must be called before creating VChart instances.
+
+### Configuration
+
+Add the following field to each extensionMark configuration:
+
+| Property    | Type      | Default | Description                                                     |
+| ----------- | --------- | ------- | --------------------------------------------------------------- |
+| `syncState` | `boolean` | `false` | Whether to synchronize interactive states from the primary mark |
+
+When using `syncState`, configure the corresponding state styles in `state` (e.g., `highlight`, `blur`, `selected`) to produce visual effects on state changes.
+
+## Important Notes
+
+1. **Data binding**: The extensionMark must have `dataId` (or `dataIndex`) configured to share the same data source with the primary mark, ensuring correct `context.key` pairing
+2. **State styles**: `syncState` only synchronizes the state name — it does not provide default styles. Configure `highlight`, `blur`, `selected`, etc. in the `state` object
+3. **Group type not supported**: `type: 'group'` extensionMarks do not support `syncState`

--- a/docs/assets/guide/zh/tutorial_docs/Chart_Extensions/extension_mark_sync_state.md
+++ b/docs/assets/guide/zh/tutorial_docs/Chart_Extensions/extension_mark_sync_state.md
@@ -1,0 +1,149 @@
+# ExtensionMark 状态同步插件
+
+当使用 `extensionMark` 在系列上补充绘制自定义图形时，这些图形默认不会跟随主图元（如柱子、点等）的交互状态（hover、select 等）变化。
+
+`ExtensionMarkSyncStatePlugin` 插件可以让配置了 `syncState: true` 的 extensionMark 自动同步主图元的交互状态，使自定义图形在交互时与主图元保持一致的视觉反馈。
+
+## 原理说明
+
+插件会在每次渲染完成后，将 extensionMark 的图形元素与主 mark 的图形元素通过 `context.key`（即数据维度标识）进行配对。当主 mark 的图形元素发生状态变化（如 hover 高亮、blur 虚化、select 选中）时，对应的 extensionMark 图形元素会自动同步相同的状态。
+
+> 注意：仅当扩展图元与主图元绑定同一条 datum（即 `context.key` 相同）时，状态同步才会生效。
+
+## 注册插件
+
+```js
+import { registerExtensionMarkSyncStatePlugin } from '@visactor/vchart-extension';
+
+// 在创建 VChart 实例之前注册
+registerExtensionMarkSyncStatePlugin();
+```
+
+如果使用 CDN 打包的全局变量 `VChartExtension`，请调用 `VChartExtension.registerExtensionMarkSyncStatePlugin()`。
+
+## 使用方式
+
+在 `extensionMark` 的配置项中添加 `syncState: true`，并配置对应的 `state` 样式即可：
+
+```javascript livedemo
+/** --在业务中使用时请添加以下代码-- */
+// 在业务中使用时, 请额外依赖 @visactor/vchart-extension，包版本保持和vchart一致
+// import { registerExtensionMarkSyncStatePlugin } from '@visactor/vchart-extension';
+/** --在业务中使用时请添加以上代码-- */
+
+/** --在业务中使用时请删除以下代码-- */
+const { registerExtensionMarkSyncStatePlugin } = VChartExtension;
+/** --在业务中使用时请删除以上代码-- */
+
+registerExtensionMarkSyncStatePlugin();
+
+const data = [
+  { category: 'A', value: 80, group: 'February' },
+  { category: 'B', value: 120, group: 'February' },
+  { category: 'C', value: 60, group: 'February' },
+  { category: 'D', value: 150, group: 'February' },
+  { category: 'A', value: 90, group: 'March' },
+  { category: 'B', value: 100, group: 'March' },
+  { category: 'C', value: 110, group: 'March' },
+  { category: 'D', value: 70, group: 'March' }
+];
+
+const spec = {
+  type: 'bar',
+  data: [{ id: 'barData', values: data }],
+  xField: 'category',
+  yField: 'value',
+  seriesField: 'group',
+  bar: {
+    state: {
+      highlight: { stroke: '#000', lineWidth: 2 },
+      blur: { fillOpacity: 0.2 },
+      selected: { stroke: 'red', lineWidth: 3 }
+    }
+  },
+  extensionMark: [
+    {
+      type: 'symbol',
+      dataId: 'barData',
+      name: 'topDot',
+      syncState: true,
+      style: {
+        fill: datum => (datum.group === 'February' ? '#1664FF' : '#1AC6FF'),
+        symbolType: 'circle',
+        size: 12,
+        x: (datum, ctx) =>
+          ctx.valueToX([datum.category]) + ctx.xBandwidth() / 4 + (datum.group === 'March' ? ctx.xBandwidth() / 2 : 0),
+        y: (datum, ctx) => ctx.valueToY([datum.value]) - 15
+      },
+      state: {
+        highlight: { fill: 'orange', size: 20, stroke: '#000', lineWidth: 2 },
+        blur: { fillOpacity: 0.15, size: 8 },
+        selected: {
+          fill: 'red',
+          size: 22,
+          outerBorder: { distance: 3, lineWidth: 2, stroke: 'red' }
+        }
+      }
+    },
+    {
+      type: 'text',
+      dataId: 'barData',
+      name: 'topLabel',
+      syncState: true,
+      style: {
+        text: datum => `${datum.value}`,
+        fontSize: 11,
+        fill: '#333',
+        textAlign: 'center',
+        textBaseline: 'bottom',
+        x: (datum, ctx) =>
+          ctx.valueToX([datum.category]) + ctx.xBandwidth() / 4 + (datum.group === 'March' ? ctx.xBandwidth() / 2 : 0),
+        y: (datum, ctx) => ctx.valueToY([datum.value]) - 26
+      },
+      state: {
+        highlight: { fill: 'orange', fontSize: 16, fontWeight: 'bold' },
+        blur: { fillOpacity: 0.1 },
+        selected: { fill: 'red', fontSize: 14, fontWeight: 'bold' }
+      }
+    }
+  ],
+  interaction: {
+    hover: { enable: true },
+    select: { enable: true }
+  },
+  legends: { visible: true, orient: 'top' },
+  title: {
+    visible: true,
+    text: 'extensionMark syncState 插件示例',
+    subtext: 'Hover / Click bar 查看状态同步效果'
+  }
+};
+
+const vchart = new VChart(spec, { dom: CONTAINER_ID });
+vchart.renderSync();
+
+// Just for the convenience of console debugging, DO NOT COPY!
+window['vchart'] = vchart;
+```
+
+## API
+
+### registerExtensionMarkSyncStatePlugin()
+
+注册 ExtensionMark 状态同步插件。需要在创建 VChart 实例之前调用。
+
+### 配置项
+
+在 `extensionMark` 的每个 mark 配置中，增加以下字段：
+
+| 属性        | 类型      | 默认值  | 说明                     |
+| ----------- | --------- | ------- | ------------------------ |
+| `syncState` | `boolean` | `false` | 是否同步主图元的交互状态 |
+
+配合 `syncState` 使用时，需在 `state` 中配置对应状态的样式（如 `highlight`、`blur`、`selected`），使状态同步后产生视觉效果。
+
+## 注意事项
+
+1. **数据绑定**：extensionMark 必须配置 `dataId`（或 `dataIndex`），以确保与主 mark 使用相同的数据，`context.key` 才能正确配对
+2. **state 样式**：`syncState` 仅同步状态名，不提供默认样式。用户需自行在 `state` 中配置 `highlight`、`blur`、`selected` 等状态样式
+3. **group 类型不支持**：`type: 'group'` 的 extensionMark 不支持 `syncState`

--- a/packages/vchart-extension/__tests__/runtime/browser/test-page/extension-mark-sync-state/index.ts
+++ b/packages/vchart-extension/__tests__/runtime/browser/test-page/extension-mark-sync-state/index.ts
@@ -203,10 +203,10 @@ const run = () => {
 
   console.log('%c[syncState 插件验证] VChart 实例已挂载到 window.__vchart__', 'color: green; font-weight: bold;');
   console.log(
-    '%c[syncState 插件验证] 可通过以下方式检查绑定情况：\n' +
+    '%c[syncState 插件验证] 可通过以下方式检查图元 key：\n' +
       '  const s = __vchart__.getChart().getAllSeries()[0];\n' +
       '  s.getMarks().forEach(m =>' +
-      ' console.log(m.name, m.getGraphics().map(g => ({key: g.context?.key, syncBind: g._syncStateBindKey}))))',
+      ' console.log(m.name, m.getGraphics().map(g => ({key: g.context?.key, states: g.currentStates}))))',
     'color: blue;'
   );
 };

--- a/packages/vchart-extension/__tests__/runtime/browser/test-page/extension-mark-sync-state/index.ts
+++ b/packages/vchart-extension/__tests__/runtime/browser/test-page/extension-mark-sync-state/index.ts
@@ -1,0 +1,214 @@
+/**
+ * extensionMark syncState 插件功能验证页面
+ *
+ * 验证场景：
+ * 1. Hover bar → extensionMark（圆点 + 文字）同步进入 highlight，其余 blur
+ * 2. Click bar → extensionMark 同步 selected 状态
+ * 3. 数据更新后重新绑定是否正常
+ * 4. API 触发 setHovered 路径
+ */
+import { default as VChart } from '@visactor/vchart';
+import { registerExtensionMarkSyncStatePlugin } from '../../../../../src';
+
+// 注册插件
+registerExtensionMarkSyncStatePlugin();
+
+const CONTAINER_ID = 'chart';
+
+const run = () => {
+  const data = [
+    { category: 'A', value: 80, group: 'February' },
+    { category: 'B', value: 120, group: 'February' },
+    { category: 'C', value: 60, group: 'February' },
+    { category: 'D', value: 150, group: 'February' },
+    { category: 'A', value: 90, group: 'March' },
+    { category: 'B', value: 100, group: 'March' },
+    { category: 'C', value: 110, group: 'March' },
+    { category: 'D', value: 70, group: 'March' }
+  ];
+
+  const spec: any = {
+    type: 'bar',
+    data: [{ id: 'barData', values: data }],
+    xField: 'category',
+    yField: 'value',
+    seriesField: 'group',
+
+    bar: {
+      state: {
+        highlight: {
+          stroke: '#000',
+          lineWidth: 2
+        },
+        blur: {
+          fillOpacity: 0.2
+        },
+        selected: {
+          stroke: 'red',
+          lineWidth: 3
+        }
+      }
+    },
+
+    // ===== extensionMark：在每个 bar 顶部画一个圆点，syncState = true =====
+    extensionMark: [
+      {
+        type: 'symbol',
+        dataId: 'barData',
+        name: 'topDot',
+        syncState: true,
+        style: {
+          fill: (datum: any) => (datum.group === 'February' ? '#1664FF' : '#1AC6FF'),
+          symbolType: 'circle',
+          size: 12,
+          x: (datum: any, ctx: any) => {
+            return (
+              ctx.valueToX([datum.category]) +
+              ctx.xBandwidth() / 4 +
+              (datum.group === 'March' ? ctx.xBandwidth() / 2 : 0)
+            );
+          },
+          y: (datum: any, ctx: any) => {
+            return ctx.valueToY([datum.value]) - 15;
+          }
+        },
+        state: {
+          highlight: {
+            fill: 'orange',
+            size: 20,
+            stroke: '#000',
+            lineWidth: 2
+          },
+          blur: {
+            fillOpacity: 0.15,
+            size: 8
+          },
+          selected: {
+            fill: 'red',
+            size: 22,
+            outerBorder: {
+              distance: 3,
+              lineWidth: 2,
+              stroke: 'red'
+            }
+          }
+        }
+      },
+      {
+        type: 'text',
+        dataId: 'barData',
+        name: 'topLabel',
+        syncState: true,
+        style: {
+          text: (datum: any) => `${datum.value}`,
+          fontSize: 11,
+          fill: '#333',
+          textAlign: 'center',
+          textBaseline: 'bottom',
+          x: (datum: any, ctx: any) => {
+            return (
+              ctx.valueToX([datum.category]) +
+              ctx.xBandwidth() / 4 +
+              (datum.group === 'March' ? ctx.xBandwidth() / 2 : 0)
+            );
+          },
+          y: (datum: any, ctx: any) => {
+            return ctx.valueToY([datum.value]) - 26;
+          }
+        },
+        state: {
+          highlight: {
+            fill: 'orange',
+            fontSize: 16,
+            fontWeight: 'bold'
+          },
+          blur: {
+            fillOpacity: 0.1
+          },
+          selected: {
+            fill: 'red',
+            fontSize: 14,
+            fontWeight: 'bold'
+          }
+        }
+      }
+    ],
+
+    // 交互配置
+    interaction: {
+      hover: {
+        enable: true
+      },
+      select: {
+        enable: true
+      }
+    },
+
+    legends: {
+      visible: true,
+      orient: 'top',
+      interactive: true
+    },
+
+    tooltip: {
+      visible: true
+    },
+
+    title: {
+      visible: true,
+      text: 'extensionMark syncState 插件验证',
+      subtext: 'Hover / Click bar → 观察圆点和数字是否同步状态'
+    }
+  };
+
+  const vchart = new VChart(spec, { dom: CONTAINER_ID });
+  vchart.renderSync();
+
+  // ===== 调试辅助：暴露到 window 方便 DevTools 检查 =====
+  (window as any).__vchart__ = vchart;
+
+  // ===== 数据更新按钮：验证数据更新后 syncState 重新绑定 =====
+  const btn = document.createElement('button');
+  btn.textContent = '更新数据（验证重新绑定）';
+  btn.style.cssText = 'margin: 4px 8px; padding: 4px 12px; cursor: pointer;';
+  btn.onclick = () => {
+    const newData = data.map(d => ({
+      ...d,
+      value: Math.round(d.value * (0.6 + Math.random() * 0.8))
+    }));
+    vchart.updateData('barData', newData);
+  };
+  document.getElementById('controlPanel')?.appendChild(btn);
+
+  // ===== setHovered API 按钮：验证 API 触发路径 =====
+  const btnApi = document.createElement('button');
+  btnApi.textContent = 'API: setHovered(A-February)';
+  btnApi.style.cssText = 'margin: 4px 8px; padding: 4px 12px; cursor: pointer;';
+  btnApi.onclick = () => {
+    vchart.setHovered({
+      category: 'A',
+      group: 'February'
+    });
+  };
+  document.getElementById('controlPanel')?.appendChild(btnApi);
+
+  // ===== clearHovered API 按钮 =====
+  const btnClear = document.createElement('button');
+  btnClear.textContent = 'API: clearHovered';
+  btnClear.style.cssText = 'margin: 4px 8px; padding: 4px 12px; cursor: pointer;';
+  btnClear.onclick = () => {
+    vchart.setHovered(null);
+  };
+  document.getElementById('controlPanel')?.appendChild(btnClear);
+
+  console.log('%c[syncState 插件验证] VChart 实例已挂载到 window.__vchart__', 'color: green; font-weight: bold;');
+  console.log(
+    '%c[syncState 插件验证] 可通过以下方式检查绑定情况：\n' +
+      '  const s = __vchart__.getChart().getAllSeries()[0];\n' +
+      '  s.getMarks().forEach(m =>' +
+      ' console.log(m.name, m.getGraphics().map(g => ({key: g.context?.key, syncBind: g._syncStateBindKey}))))',
+    'color: blue;'
+  );
+};
+
+run();

--- a/packages/vchart-extension/src/components/extension-mark-sync-state/extension-mark-sync-state.ts
+++ b/packages/vchart-extension/src/components/extension-mark-sync-state/extension-mark-sync-state.ts
@@ -2,10 +2,11 @@
  * @description ExtensionMark SyncState 插件
  *
  * 将配置了 syncState: true 的 extensionMark 的 graphics 与主 mark 的 graphics
- * 通过 context.key 配对，在主 mark graphic 上监听 afterStateUpdate 事件，
- * 回调中同步状态到 extensionMark graphic。
+ * 通过 context.key 配对，在 afterRender 回调中将主 mark 的当前状态同步到
+ * extensionMark graphic。
  *
- * 参考 VRender Label 的 syncState 实现。
+ * 由于 afterRender 在每次状态更新完成后都会触发，因此无需在单个 graphic 上
+ * 额外监听 afterStateUpdate 事件。
  */
 import {
   type IChartPlugin,
@@ -28,7 +29,6 @@ export class ExtensionMarkSyncStatePlugin extends BasePlugin implements IChartPl
   static readonly type: string = EXTENSION_MARK_SYNC_STATE_PLUGIN_TYPE;
   readonly type: string = EXTENSION_MARK_SYNC_STATE_PLUGIN_TYPE;
 
-  private _bindHandlers: Array<{ bindTarget: IMarkGraphic; handler: () => void }> = [];
   private _afterRenderHandler?: () => void;
 
   constructor() {
@@ -56,19 +56,15 @@ export class ExtensionMarkSyncStatePlugin extends BasePlugin implements IChartPl
       return;
     }
 
-    // 注册 afterRender 事件，每次渲染完成后建立状态同步关联
+    // 注册 afterRender 事件，每次渲染完成后直接同步状态
+    // afterRender 在每次状态更新完成后都会触发，因此无需额外监听单个 graphic 的状态变化
     this._afterRenderHandler = () => {
-      this._bindSyncState(service);
+      this._syncStates(service);
     };
     chart.getEvent().on(ChartEvent.afterRender, this._afterRenderHandler);
   }
 
   release(): void {
-    // 清理所有 afterStateUpdate 监听
-    this._bindHandlers.forEach(({ bindTarget, handler }) => {
-      bindTarget.off('afterStateUpdate', handler);
-    });
-    this._bindHandlers = [];
     this._afterRenderHandler = undefined;
     super.release();
   }
@@ -101,9 +97,9 @@ export class ExtensionMarkSyncStatePlugin extends BasePlugin implements IChartPl
 
   /**
    * 遍历所有 series，找到配置了 syncState 的 extensionMark，
-   * 将其 graphics 与主 mark 的 graphics 通过 context.key 配对并建立状态同步
+   * 将其 graphics 与主 mark 的 graphics 通过 context.key 配对并同步状态
    */
-  private _bindSyncState(service: IChartPluginService) {
+  private _syncStates(service: IChartPluginService) {
     const chart = service.globalInstance.getChart();
     if (!chart) {
       return;
@@ -117,14 +113,14 @@ export class ExtensionMarkSyncStatePlugin extends BasePlugin implements IChartPl
         return;
       }
 
-      this._bindSeriesSyncState(series, extensionMarkSpecs);
+      this._syncSeriesStates(series, extensionMarkSpecs);
     });
   }
 
   /**
-   * 对单个 series 建立 extensionMark 与主 mark 的状态同步
+   * 对单个 series，将主 mark 的当前状态同步到 extensionMark
    */
-  private _bindSeriesSyncState(series: ISeries, extensionMarkSpecs: IExtensionMarkSpecWithSyncState[]) {
+  private _syncSeriesStates(series: ISeries, extensionMarkSpecs: IExtensionMarkSpecWithSyncState[]) {
     // 收集主 mark 的 graphics，按 context.key 建立索引
     const activeMarks = series.getActiveMarks();
     const mainGraphicByKey = new Map<string, IMarkGraphic>();
@@ -155,7 +151,7 @@ export class ExtensionMarkSyncStatePlugin extends BasePlugin implements IChartPl
         return;
       }
 
-      extMark.getGraphics().forEach((extGraphic: IMarkGraphic & Record<string, any>) => {
+      extMark.getGraphics().forEach(extGraphic => {
         const key = extGraphic.context?.key;
         if (!isValid(key)) {
           return;
@@ -166,40 +162,13 @@ export class ExtensionMarkSyncStatePlugin extends BasePlugin implements IChartPl
           return;
         }
 
-        // 立即同步一次当前状态
+        // 直接同步主 graphic 的当前状态
         const currentStates = mainGraphic.currentStates;
         if (currentStates?.length) {
           extGraphic.useStates(currentStates);
+        } else {
+          extGraphic.clearStates();
         }
-
-        // 避免重复绑定：通过标记位判断
-        if (extGraphic._syncStateBindKey === key && extGraphic._syncStateBindTarget === mainGraphic) {
-          return;
-        }
-
-        // 清理旧监听（如果之前绑定过不同的 mainGraphic）
-        if (extGraphic._syncStateHandler && extGraphic._syncStateBindTarget) {
-          extGraphic._syncStateBindTarget.off('afterStateUpdate', extGraphic._syncStateHandler);
-          // 从 _bindHandlers 中移除旧记录
-          this._bindHandlers = this._bindHandlers.filter(
-            h => !(h.bindTarget === extGraphic._syncStateBindTarget && h.handler === extGraphic._syncStateHandler)
-          );
-        }
-
-        // 建立新监听
-        const handler = () => {
-          const states = mainGraphic.currentStates ?? [];
-          extGraphic.useStates(states);
-        };
-        mainGraphic.on('afterStateUpdate', handler);
-
-        // 记录绑定信息，用于下次去重/清理
-        extGraphic._syncStateHandler = handler;
-        extGraphic._syncStateBindKey = key;
-        extGraphic._syncStateBindTarget = mainGraphic;
-
-        // 记录到插件级别的清理列表
-        this._bindHandlers.push({ bindTarget: mainGraphic, handler });
       });
     });
   }

--- a/packages/vchart-extension/src/components/extension-mark-sync-state/extension-mark-sync-state.ts
+++ b/packages/vchart-extension/src/components/extension-mark-sync-state/extension-mark-sync-state.ts
@@ -1,0 +1,244 @@
+/**
+ * @description ExtensionMark SyncState 插件
+ *
+ * 将配置了 syncState: true 的 extensionMark 的 graphics 与主 mark 的 graphics
+ * 通过 context.key 配对，在主 mark graphic 上监听 afterStateUpdate 事件，
+ * 回调中同步状态到 extensionMark graphic。
+ *
+ * 参考 VRender Label 的 syncState 实现。
+ */
+import {
+  type IChartPlugin,
+  type IChartPluginService,
+  type ISeries,
+  type IMark,
+  type IMarkGraphic,
+  type VChartRenderActionSource,
+  BasePlugin,
+  ChartEvent,
+  registerChartPlugin,
+  isValid
+} from '@visactor/vchart';
+import type { IExtensionMarkSpecWithSyncState } from './type';
+
+const EXTENSION_MARK_SYNC_STATE_PLUGIN_TYPE = 'ExtensionMarkSyncStatePlugin';
+
+export class ExtensionMarkSyncStatePlugin extends BasePlugin implements IChartPlugin {
+  static readonly pluginType: 'chart' = 'chart';
+  static readonly type: string = EXTENSION_MARK_SYNC_STATE_PLUGIN_TYPE;
+  readonly type: string = EXTENSION_MARK_SYNC_STATE_PLUGIN_TYPE;
+
+  private _bindHandlers: Array<{ bindTarget: IMarkGraphic; handler: () => void }> = [];
+  private _afterRenderHandler?: () => void;
+
+  constructor() {
+    super(EXTENSION_MARK_SYNC_STATE_PLUGIN_TYPE);
+  }
+
+  private _hasSyncState = false;
+
+  onInit(service: IChartPluginService, chartSpec: any) {
+    // onInit 阶段 chart 尚未创建，仅做 spec 检测
+    this._hasSyncState = this._detectSyncState(chartSpec);
+  }
+
+  onAfterInitChart(service: IChartPluginService, chartSpec: any, _actionSource: VChartRenderActionSource) {
+    if (!this._hasSyncState) {
+      // updateSpec 场景：重新检测
+      this._hasSyncState = this._detectSyncState(chartSpec);
+      if (!this._hasSyncState) {
+        return;
+      }
+    }
+
+    const chart = service.globalInstance.getChart();
+    if (!chart) {
+      return;
+    }
+
+    // 注册 afterRender 事件，每次渲染完成后建立状态同步关联
+    this._afterRenderHandler = () => {
+      this._bindSyncState(service);
+    };
+    chart.getEvent().on(ChartEvent.afterRender, this._afterRenderHandler);
+  }
+
+  release(): void {
+    // 清理所有 afterStateUpdate 监听
+    this._bindHandlers.forEach(({ bindTarget, handler }) => {
+      bindTarget.off('afterStateUpdate', handler);
+    });
+    this._bindHandlers = [];
+    this._afterRenderHandler = undefined;
+    super.release();
+  }
+
+  /**
+   * 检测 chartSpec 中是否存在配置了 syncState 的 extensionMark
+   */
+  private _detectSyncState(chartSpec: any): boolean {
+    // 检查顶层 series spec 中的 extensionMark
+    const seriesSpecs = chartSpec?.series;
+    if (seriesSpecs) {
+      for (const seriesSpec of seriesSpecs) {
+        if (this._hasExtensionMarkSyncState(seriesSpec.extensionMark)) {
+          return true;
+        }
+      }
+    }
+
+    // 非 common chart 时，extensionMark 可直接配置在顶层 spec 上
+    if (this._hasExtensionMarkSyncState(chartSpec?.extensionMark)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private _hasExtensionMarkSyncState(extensionMarks: IExtensionMarkSpecWithSyncState[] | undefined): boolean {
+    return !!extensionMarks?.some(m => m.type !== 'group' && m.syncState);
+  }
+
+  /**
+   * 遍历所有 series，找到配置了 syncState 的 extensionMark，
+   * 将其 graphics 与主 mark 的 graphics 通过 context.key 配对并建立状态同步
+   */
+  private _bindSyncState(service: IChartPluginService) {
+    const chart = service.globalInstance.getChart();
+    if (!chart) {
+      return;
+    }
+
+    const allSeries = chart.getAllSeries();
+    allSeries.forEach(series => {
+      const spec = series.getSpec();
+      const extensionMarkSpecs: IExtensionMarkSpecWithSyncState[] | undefined = spec?.extensionMark;
+      if (!extensionMarkSpecs?.some(m => m.type !== 'group' && m.syncState)) {
+        return;
+      }
+
+      this._bindSeriesSyncState(series, extensionMarkSpecs);
+    });
+  }
+
+  /**
+   * 对单个 series 建立 extensionMark 与主 mark 的状态同步
+   */
+  private _bindSeriesSyncState(series: ISeries, extensionMarkSpecs: IExtensionMarkSpecWithSyncState[]) {
+    // 收集主 mark 的 graphics，按 context.key 建立索引
+    const activeMarks = series.getActiveMarks();
+    const mainGraphicByKey = new Map<string, IMarkGraphic>();
+
+    activeMarks.forEach((mark: IMark) => {
+      mark.getGraphics().forEach(g => {
+        const key = g.context?.key;
+        if (isValid(key)) {
+          mainGraphicByKey.set(String(key), g);
+        }
+      });
+    });
+
+    if (mainGraphicByKey.size === 0) {
+      return;
+    }
+
+    const namePrefix = this._getExtensionMarkNamePrefix(series);
+
+    extensionMarkSpecs.forEach((spec, i) => {
+      if (spec.type === 'group' || !spec.syncState) {
+        return;
+      }
+
+      const markName = isValid(spec.name) ? `${spec.name}` : `${namePrefix}_${i}`;
+      const extMark = series.getMarkInName(markName);
+      if (!extMark) {
+        return;
+      }
+
+      extMark.getGraphics().forEach((extGraphic: IMarkGraphic & Record<string, any>) => {
+        const key = extGraphic.context?.key;
+        if (!isValid(key)) {
+          return;
+        }
+
+        const mainGraphic = mainGraphicByKey.get(String(key));
+        if (!mainGraphic) {
+          return;
+        }
+
+        // 立即同步一次当前状态
+        const currentStates = mainGraphic.currentStates;
+        if (currentStates?.length) {
+          extGraphic.useStates(currentStates);
+        }
+
+        // 避免重复绑定：通过标记位判断
+        if (extGraphic._syncStateBindKey === key && extGraphic._syncStateBindTarget === mainGraphic) {
+          return;
+        }
+
+        // 清理旧监听（如果之前绑定过不同的 mainGraphic）
+        if (extGraphic._syncStateHandler && extGraphic._syncStateBindTarget) {
+          extGraphic._syncStateBindTarget.off('afterStateUpdate', extGraphic._syncStateHandler);
+          // 从 _bindHandlers 中移除旧记录
+          this._bindHandlers = this._bindHandlers.filter(
+            h => !(h.bindTarget === extGraphic._syncStateBindTarget && h.handler === extGraphic._syncStateHandler)
+          );
+        }
+
+        // 建立新监听
+        const handler = () => {
+          const states = mainGraphic.currentStates ?? [];
+          extGraphic.useStates(states);
+        };
+        mainGraphic.on('afterStateUpdate', handler);
+
+        // 记录绑定信息，用于下次去重/清理
+        extGraphic._syncStateHandler = handler;
+        extGraphic._syncStateBindKey = key;
+        extGraphic._syncStateBindTarget = mainGraphic;
+
+        // 记录到插件级别的清理列表
+        this._bindHandlers.push({ bindTarget: mainGraphic, handler });
+      });
+    });
+  }
+
+  /**
+   * 重建 extensionMark 的命名前缀
+   * 与 BaseSeries._getExtensionMarkNamePrefix 保持一致：`${series.type}_${series.id}_extensionMark`
+   */
+  private _getExtensionMarkNamePrefix(series: ISeries): string {
+    return `${series.type}_${series.id}_extensionMark`;
+  }
+}
+
+/**
+ * 注册 ExtensionMark SyncState 插件
+ *
+ * @example
+ * ```ts
+ * import { registerExtensionMarkSyncStatePlugin } from '@visactor/vchart-extension';
+ *
+ * // 在创建 VChart 实例之前注册
+ * registerExtensionMarkSyncStatePlugin();
+ *
+ * // 在 extensionMark 配置中使用 syncState
+ * const spec = {
+ *   type: 'bar',
+ *   extensionMark: [{
+ *     type: 'symbol',
+ *     dataId: 'barData',
+ *     syncState: true,
+ *     style: { ... },
+ *     state: {
+ *       highlight: { ... },
+ *       blur: { ... }
+ *     }
+ *   }]
+ * };
+ * ```
+ */
+export const registerExtensionMarkSyncStatePlugin = () => {
+  registerChartPlugin(ExtensionMarkSyncStatePlugin);
+};

--- a/packages/vchart-extension/src/components/extension-mark-sync-state/extension-mark-sync-state.ts
+++ b/packages/vchart-extension/src/components/extension-mark-sync-state/extension-mark-sync-state.ts
@@ -4,9 +4,6 @@
  * 将配置了 syncState: true 的 extensionMark 的 graphics 与主 mark 的 graphics
  * 通过 context.key 配对，在 afterRender 回调中将主 mark 的当前状态同步到
  * extensionMark graphic。
- *
- * 由于 afterRender 在每次状态更新完成后都会触发，因此无需在单个 graphic 上
- * 额外监听 afterStateUpdate 事件。
  */
 import {
   type IChartPlugin,
@@ -14,7 +11,8 @@ import {
   type ISeries,
   type IMark,
   type IMarkGraphic,
-  type VChartRenderActionSource,
+  type IEvent,
+  type ISeriesSpec,
   BasePlugin,
   ChartEvent,
   registerChartPlugin,
@@ -24,31 +22,23 @@ import type { IExtensionMarkSpecWithSyncState } from './type';
 
 const EXTENSION_MARK_SYNC_STATE_PLUGIN_TYPE = 'ExtensionMarkSyncStatePlugin';
 
-export class ExtensionMarkSyncStatePlugin extends BasePlugin implements IChartPlugin {
+export class ExtensionMarkSyncStatePlugin extends BasePlugin<IChartPluginService> implements IChartPlugin {
   static readonly pluginType: 'chart' = 'chart';
   static readonly type: string = EXTENSION_MARK_SYNC_STATE_PLUGIN_TYPE;
   readonly type: string = EXTENSION_MARK_SYNC_STATE_PLUGIN_TYPE;
 
-  private _afterRenderHandler?: () => void;
+  /** 取消 afterRender 订阅的函数，release 时调用 */
+  private _unsubscribeAfterRender?: () => void;
+  /** 已订阅的 event 实例，chart reMake 后会更换 */
+  private _subscribedEvent?: IEvent;
 
   constructor() {
     super(EXTENSION_MARK_SYNC_STATE_PLUGIN_TYPE);
   }
 
-  private _hasSyncState = false;
-
-  onInit(service: IChartPluginService, chartSpec: any) {
-    // onInit 阶段 chart 尚未创建，仅做 spec 检测
-    this._hasSyncState = this._detectSyncState(chartSpec);
-  }
-
-  onAfterInitChart(service: IChartPluginService, chartSpec: any, _actionSource: VChartRenderActionSource) {
-    if (!this._hasSyncState) {
-      // updateSpec 场景：重新检测
-      this._hasSyncState = this._detectSyncState(chartSpec);
-      if (!this._hasSyncState) {
-        return;
-      }
+  onAfterInitChart(service: IChartPluginService, chartSpec: any) {
+    if (!this._detectSyncState(chartSpec)) {
+      return;
     }
 
     const chart = service.globalInstance.getChart();
@@ -56,76 +46,66 @@ export class ExtensionMarkSyncStatePlugin extends BasePlugin implements IChartPl
       return;
     }
 
-    // 注册 afterRender 事件，每次渲染完成后直接同步状态
-    // afterRender 在每次状态更新完成后都会触发，因此无需额外监听单个 graphic 的状态变化
-    this._afterRenderHandler = () => {
-      this._syncStates(service);
+    const event = chart.getEvent();
+
+    if (this._subscribedEvent === event) {
+      return;
+    }
+
+    this._unsubscribeAfterRender?.();
+
+    const handler = () => this._syncStates();
+    event.on(ChartEvent.afterRender, handler);
+    this._subscribedEvent = event;
+    this._unsubscribeAfterRender = () => {
+      event.off(ChartEvent.afterRender, handler);
+      this._subscribedEvent = undefined;
     };
-    chart.getEvent().on(ChartEvent.afterRender, this._afterRenderHandler);
   }
 
   release(): void {
-    this._afterRenderHandler = undefined;
+    this._unsubscribeAfterRender?.();
     super.release();
   }
 
-  /**
-   * 检测 chartSpec 中是否存在配置了 syncState 的 extensionMark
-   */
+  /** 检测 chartSpec 中是否存在配置了 syncState 的 extensionMark */
   private _detectSyncState(chartSpec: any): boolean {
-    // 检查顶层 series spec 中的 extensionMark
     const seriesSpecs = chartSpec?.series;
-    if (seriesSpecs) {
-      for (const seriesSpec of seriesSpecs) {
-        if (this._hasExtensionMarkSyncState(seriesSpec.extensionMark)) {
-          return true;
-        }
-      }
-    }
-
-    // 非 common chart 时，extensionMark 可直接配置在顶层 spec 上
-    if (this._hasExtensionMarkSyncState(chartSpec?.extensionMark)) {
+    if (
+      seriesSpecs?.some((s: ISeriesSpec) =>
+        this._hasExtensionMarkWithSyncState(s.extensionMark as IExtensionMarkSpecWithSyncState[])
+      )
+    ) {
       return true;
     }
-
-    return false;
+    return this._hasExtensionMarkWithSyncState(chartSpec?.extensionMark);
   }
 
-  private _hasExtensionMarkSyncState(extensionMarks: IExtensionMarkSpecWithSyncState[] | undefined): boolean {
+  private _hasExtensionMarkWithSyncState(extensionMarks: IExtensionMarkSpecWithSyncState[] | undefined): boolean {
     return !!extensionMarks?.some(m => m.type !== 'group' && m.syncState);
   }
 
-  /**
-   * 遍历所有 series，找到配置了 syncState 的 extensionMark，
-   * 将其 graphics 与主 mark 的 graphics 通过 context.key 配对并同步状态
-   */
-  private _syncStates(service: IChartPluginService) {
-    const chart = service.globalInstance.getChart();
+  /** 将所有 series 中主 mark 的当前状态同步到对应的 extensionMark graphics */
+  private _syncStates() {
+    const chart = this.service?.globalInstance.getChart();
     if (!chart) {
       return;
     }
 
-    const allSeries = chart.getAllSeries();
-    allSeries.forEach(series => {
-      const spec = series.getSpec();
-      const extensionMarkSpecs: IExtensionMarkSpecWithSyncState[] | undefined = spec?.extensionMark;
-      if (!extensionMarkSpecs?.some(m => m.type !== 'group' && m.syncState)) {
-        return;
+    chart.getAllSeries().forEach(series => {
+      const syncSpecs = (series.getSpec()?.extensionMark as IExtensionMarkSpecWithSyncState[] | undefined)?.filter(
+        m => m.type !== 'group' && m.syncState
+      );
+      if (syncSpecs?.length) {
+        this._syncSeriesStates(series, syncSpecs);
       }
-
-      this._syncSeriesStates(series, extensionMarkSpecs);
     });
   }
 
-  /**
-   * 对单个 series，将主 mark 的当前状态同步到 extensionMark
-   */
+  /** 将单个 series 主 mark 的当前状态同步到其 extensionMark graphics */
   private _syncSeriesStates(series: ISeries, extensionMarkSpecs: IExtensionMarkSpecWithSyncState[]) {
-    // 收集主 mark 的 graphics，按 context.key 建立索引
-    const activeMarks = series.getActiveMarks();
     const mainGraphicByKey = new Map<string, IMarkGraphic>();
-
-    activeMarks.forEach((mark: IMark) => {
+    series.getActiveMarks().forEach((mark: IMark) => {
       mark.getGraphics().forEach(g => {
         const key = g.context?.key;
         if (isValid(key)) {
@@ -138,13 +118,10 @@ export class ExtensionMarkSyncStatePlugin extends BasePlugin implements IChartPl
       return;
     }
 
-    const namePrefix = this._getExtensionMarkNamePrefix(series);
+    // 命名格式与 BaseSeries._getExtensionMarkNamePrefix 一致
+    const namePrefix = `${series.type}_${series.id}_extensionMark`;
 
     extensionMarkSpecs.forEach((spec, i) => {
-      if (spec.type === 'group' || !spec.syncState) {
-        return;
-      }
-
       const markName = isValid(spec.name) ? `${spec.name}` : `${namePrefix}_${i}`;
       const extMark = series.getMarkInName(markName);
       if (!extMark) {
@@ -162,7 +139,6 @@ export class ExtensionMarkSyncStatePlugin extends BasePlugin implements IChartPl
           return;
         }
 
-        // 直接同步主 graphic 的当前状态
         const currentStates = mainGraphic.currentStates;
         if (currentStates?.length) {
           extGraphic.useStates(currentStates);
@@ -171,14 +147,6 @@ export class ExtensionMarkSyncStatePlugin extends BasePlugin implements IChartPl
         }
       });
     });
-  }
-
-  /**
-   * 重建 extensionMark 的命名前缀
-   * 与 BaseSeries._getExtensionMarkNamePrefix 保持一致：`${series.type}_${series.id}_extensionMark`
-   */
-  private _getExtensionMarkNamePrefix(series: ISeries): string {
-    return `${series.type}_${series.id}_extensionMark`;
   }
 }
 

--- a/packages/vchart-extension/src/components/extension-mark-sync-state/index.ts
+++ b/packages/vchart-extension/src/components/extension-mark-sync-state/index.ts
@@ -1,0 +1,2 @@
+export { ExtensionMarkSyncStatePlugin, registerExtensionMarkSyncStatePlugin } from './extension-mark-sync-state';
+export * from './type';

--- a/packages/vchart-extension/src/components/extension-mark-sync-state/type.ts
+++ b/packages/vchart-extension/src/components/extension-mark-sync-state/type.ts
@@ -1,0 +1,29 @@
+import type { EnableMarkType } from '@visactor/vchart';
+
+/**
+ * 扩展 extensionMark spec，增加 syncState 配置
+ */
+export interface IExtensionMarkSyncStateSpec {
+  /**
+   * Whether to synchronize the interactive states (e.g., hover, select) from the corresponding primary mark.
+   * When enabled, the extensionMark will automatically follow state changes of the primary mark that shares
+   * the same data key. Users need to configure the corresponding `state` styles to take effect.
+   * 是否同步主图元的交互状态（如 hover、select 等）
+   * 开启后，extensionMark 会自动同步对应主图元的状态名，需自行配置对应的 state 样式
+   * @default false
+   */
+  syncState?: boolean;
+}
+
+/**
+ * 带 syncState 能力的 extensionMark spec
+ */
+export interface IExtensionMarkSpecWithSyncState<
+  T extends Exclude<EnableMarkType, 'group'> = any
+> extends IExtensionMarkSyncStateSpec {
+  type: T;
+  name?: string;
+  dataId?: string;
+  dataIndex?: number;
+  [key: string]: any;
+}

--- a/packages/vchart-extension/src/index.ts
+++ b/packages/vchart-extension/src/index.ts
@@ -27,3 +27,4 @@ export * from './components/regression-line';
 export * from './components/scatter-regression-line';
 export * from './components/bar-regression-line';
 export * from './components/histogram-regression-line';
+export * from './components/extension-mark-sync-state';


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/VisActor/VChart/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Release
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!-- None -->

### 🔗 Related PR link

<!-- None -->

### 🐞 Bugserver case id

<!-- N/A -->

### 💡 Background and solution

When using `extensionMark` to draw custom graphics on a series, those graphics do not follow the interactive states (hover, select, etc.) of the primary mark by default. This creates a visual inconsistency when users interact with the chart.

**Solution**: Add a new `ExtensionMarkSyncStatePlugin` to `@visactor/vchart-extension`. When an `extensionMark` is configured with `syncState: true`, the plugin automatically synchronizes the primary mark's interactive states (highlight, blur, selected, etc.) to the corresponding extension mark graphics, matched by `context.key` (data dimension identifier).

**API**:
```js
import { registerExtensionMarkSyncStatePlugin } from '@visactor/vchart-extension';

// Register before creating VChart instance
registerExtensionMarkSyncStatePlugin();
```

```js
// In spec, add syncState: true to extensionMark entries
extensionMark: [
  {
    type: 'symbol',
    dataId: 'barData',
    syncState: true,
    state: {
      highlight: { fill: 'orange', size: 20 },
      blur: { fillOpacity: 0.15 },
      selected: { fill: 'red', size: 22 }
    }
  }
]
```

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | feat: add `ExtensionMarkSyncStatePlugin` in `@visactor/vchart-extension` — enables `extensionMark` to automatically synchronize interactive states (hover/select/blur) from the corresponding primary mark via `syncState: true` config |
| 🇨🇳 Chinese | feat: 在 `@visactor/vchart-extension` 中新增 `ExtensionMarkSyncStatePlugin` —— 通过 `syncState: true` 配置，让 extensionMark 自动同步主图元的交互状态（hover/select/blur） |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

### 🚀 Summary
copilot:summary

### 🔍 Walkthrough
copilot:walkthrough