### PR TITLE
fix: re-nice linear axis with the real plot-area length after layout

### DIFF
--- a/common/changes/@visactor/vchart/fix-linear-axis-relayout-nice_2026-06-12-08-00.json
+++ b/common/changes/@visactor/vchart/fix-linear-axis-relayout-nice_2026-06-12-08-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: re-nice the cartesian linear axis with the real plot-area length after layout when `tick.tickCount` is a function, so the length-based tick count and nice ceiling match the final plot area instead of the pre-layout chart viewRect",
+      "type": "patch",
+      "packageName": "@visactor/vchart"
+    }
+  ],
+  "packageName": "@visactor/vchart",
+  "email": "chendaxin.tk@bytedance.com"
+}

--- a/packages/vchart/__tests__/unit/component/cartesian/axis/linear-axis.test.ts
+++ b/packages/vchart/__tests__/unit/component/cartesian/axis/linear-axis.test.ts
@@ -671,3 +671,59 @@ test('dynamic tickCount with wilkson', () => {
     .map((tick: any) => tick.value);
   expect(tickValues).toEqual([0, 25, 50, 75, 100]);
 });
+
+test('re-nice value axis with the real plot-area length on updateScaleRange when tickCount is a function', () => {
+  // 数据域 [0, 700]（collectData 是 protected，用 `as any` 绕过类型检查）
+  jest.spyOn(CartesianAxis.prototype as any, 'collectData').mockImplementation(() => [{ min: 0, max: 700 }]);
+
+  // tickCount 依赖轴长（轴越长刻度越多），记录每次拿到的 axisLength
+  const seenAxisLength: number[] = [];
+  let spec = getAxisSpec({
+    orient: 'left',
+    tick: {
+      tickMode: 'd3',
+      tickCount: ({ axisLength }: { axisLength: number }) => {
+        seenAxisLength.push(axisLength);
+        return Math.max(2, Math.round(axisLength / 100));
+      }
+    }
+  });
+  const transformer = new CartesianAxis.transformerConstructor({
+    type: 'cartesianAxis-linear',
+    getTheme: getTheme,
+    mode: 'desktop-browser'
+  });
+  spec = transformer.transformSpec(spec, {}).spec;
+  const linearAxis = CartesianAxis.createComponent(
+    {
+      type: getCartesianAxisInfo(spec).componentName,
+      spec
+    },
+    ctx
+  ) as any;
+
+  linearAxis.created();
+  linearAxis.init({});
+
+  // 布局前：scale.range 仍是 [0, 1]，setLinearScaleNice 回退用整块 chart viewRect 高度(500)
+  linearAxis.updateScaleDomain();
+  expect(seenAxisLength).toContain(500);
+  // viewRect 高度 500 → tickCount 5 → nice 域 [0, 700]
+  expect(linearAxis.getScale().domain()).toEqual([0, 700]);
+
+  // 模拟布局：让 updateScaleRange 解析出真实绘图区轴长 200（远小于 viewRect 的 500），
+  // 走真正的修复入口 updateScaleRange()，而不是直接调内部的 reTransformDomainByLayout()——
+  // 这样一旦 updateScaleRange() 覆盖被移除，本用例就会失败。
+  seenAxisLength.length = 0;
+  jest.spyOn(linearAxis, 'getNewScaleRange').mockReturnValue([200, 0]);
+  linearAxis.updateScaleRange();
+
+  // updateScaleRange 内部用真实轴长 200 重算，而不是布局前回退的 viewRect 500
+  expect(seenAxisLength).toContain(200);
+  expect(seenAxisLength).not.toContain(500);
+  // 真实轴更短 → tickCount 2 → nice 天花板抬到 [0, 1000]
+  expect(linearAxis.getScale().domain()).toEqual([0, 1000]);
+
+  // 恢复全局 collectData mock，避免影响其他用例
+  jest.spyOn(CartesianAxis.prototype as any, 'collectData').mockImplementation(() => [{ min: 569, max: 901 }]);
+});

--- a/packages/vchart/src/component/axis/cartesian/linear-axis.ts
+++ b/packages/vchart/src/component/axis/cartesian/linear-axis.ts
@@ -27,6 +27,7 @@ export interface CartesianLinearAxis<T extends ICartesianLinearAxisSpec = ICarte
       | 'computeLinearDomain'
       | 'valueToPosition'
       | 'setScaleNice'
+      | 'reTransformDomainByLayout'
       | '_domain'
       | 'transformScaleDomain'
       | 'setExtendDomain'
@@ -78,6 +79,22 @@ export class CartesianLinearAxis<
     }
     this._scale.domain(range);
     // this.setScaleNice();
+  }
+
+  /**
+   * @override
+   * scale.range 更新到真实绘图区长度后，立刻用真实轴长重算依赖轴长的 nice（tickCount 为函数时）。
+   * 这里既覆盖布局测量阶段（getBoundsInRect 内、computeData('range') 与 bounds 测量之前），
+   * 也覆盖 onLayoutEnd（基类 onLayoutEnd 同样会调 updateScaleRange），
+   * 从而让刻度数 / nice 天花板与最终绘图区一致，且 bounds 测量基于正确刻度（不会按布局前 viewRect
+   * 的偏密刻度分配轴空间）。详见 LinearAxisMixin.reTransformDomainByLayout
+   */
+  updateScaleRange() {
+    const isScaleChange = super.updateScaleRange();
+    if (isScaleChange) {
+      this.reTransformDomainByLayout();
+    }
+    return isScaleChange;
   }
 
   protected _tickTransformOption() {

--- a/packages/vchart/src/component/axis/mixin/linear-axis-mixin.ts
+++ b/packages/vchart/src/component/axis/mixin/linear-axis-mixin.ts
@@ -36,6 +36,11 @@ export interface LinearAxisMixin {
   _softMaxValue?: number;
   _expand?: { max?: number; min?: number };
   _tick: ITick | undefined;
+  /**
+   * 上一次 setLinearScaleNice 计算 tickCount 时使用的轴长，
+   * 用于布局结束后判断是否需要用真实绘图区轴长重新 nice
+   */
+  _lastNiceAxisLength?: number;
   isSeriesDataEnable: any;
   computeDomain: any;
   collectData: (depth?: number, rawData?: boolean) => { min: number; max: number; values: any[] }[];
@@ -93,6 +98,9 @@ export class LinearAxisMixin {
         rangeSize = isX ? this._option.getChartViewRect().width : this._option.getChartViewRect().height;
       }
 
+      // 记录本次 nice 使用的轴长，供布局结束后判断是否需要用真实绘图区轴长重算
+      this._lastNiceAxisLength = rangeSize;
+
       // tickCount需要一致，不然会导致效果不一致, fix #2050
       tickCount = tick.tickCount({
         axisLength: rangeSize,
@@ -142,6 +150,33 @@ export class LinearAxisMixin {
       return this.setLogScaleNice();
     }
     return this.setLinearScaleNice();
+  }
+
+  /**
+   * scale.range 更新到真实绘图区长度后，若 tickCount 是依赖轴长的函数，用真实轴长重算 nice。
+   *
+   * setLinearScaleNice 在布局前被调用时（scale.range 仍是初始的 [0, 1]、rangeSize 为 1），
+   * 拿不到真实绘图区像素轴长，会回退用整块 chart viewRect 的宽/高估算 tickCount。viewRect
+   * 比扣掉标题/图例/对侧轴后的真实绘图区大，导致 tickCount 偏大 → 刻度偏密 → nice 天花板偏低，
+   * 且布局后不会再重算。这里在 range 更新到真实绘图区长度后重算一次，使 tickCount / nice 域与最终
+   * 绘图区一致。仅当 tickCount 为函数（依赖轴长）时生效，固定/默认 tickCount 不受影响；
+   * _lastNiceAxisLength 缓存避免轴长未变时（多次布局测量 / 多 pass）重复重算。
+   */
+  reTransformDomainByLayout() {
+    if (!this._nice || !isFunction(this._spec.tick?.tickCount)) {
+      return;
+    }
+    const range = this._scale.range();
+    const realLength = Math.abs(last(range) - range[0]);
+    // range 还没更新到真实绘图区（仍是初始 [0, 1]）时不处理
+    if (realLength <= 1) {
+      return;
+    }
+    // 已经用同样的轴长 nice 过则跳过，避免多次布局 pass 下重复重算
+    if (isValidNumber(this._lastNiceAxisLength) && Math.abs(this._lastNiceAxisLength - realLength) < 1) {
+      return;
+    }
+    this.updateScaleDomain();
   }
 
   dataToPosition(values: any[], cfg?: IAxisLocationCfg): number {


### PR DESCRIPTION
## Problem

When a cartesian **linear (value) axis** uses a **function** `tick.tickCount` (i.e. the tick count depends on the axis length), the ticks come out too dense and the niced ceiling too low compared to the real plot area.

The root cause is already flagged by a `TODO` in `linear-axis-mixin.ts` (`setLinearScaleNice`):

```ts
if (rangeSize === 1 && this._option) {
  // TODO: need to be optimized, when the range is not updated, use the size of view
  const isX = isXAxis(this._orient);
  rangeSize = isX ? this._option.getChartViewRect().width : this._option.getChartViewRect().height;
}
```

`setLinearScaleNice` runs **before layout**, while `scale.range()` is still the initial `[0, 1]` (`rangeSize === 1`). In that case it falls back to the whole chart `viewRect` to estimate the axis length. But `viewRect` is larger than the real plot area (it still includes title / legend / opposite axis / padding), so:

- the `axisLength` passed to `tickCount(...)` is too large → `tickCount` too large → ticks too dense;
- the niced domain ceiling ends up lower than it should be.

After layout the scale range is updated to the real plot-area length (`onLayoutEnd → updateScaleRange`), but the nice computation is **never re-run**, so the wrong tick count / ceiling persists.

## Fix

`CartesianLinearAxis.onLayoutEnd` now re-runs the domain + nice computation once, after the scale range reflects the real plot-area pixel length:

- It only takes effect when `tick.tickCount` is a **function** (length-dependent). Fixed `tickCount`, `forceTickCount`, and the default count are range-independent and are left untouched → **no behavior change for existing users**.
- A cached "last nice axis length" (`_lastNiceAxisLength`) skips the recompute when the axis length hasn't changed, guarding against redundant work / re-entrancy across multiple layout passes.

## Scope / safety

- No-op unless `tick.tickCount` is a function.
- Reuses the existing `updateScaleDomain()` path (the same path used when series data changes), so domain extensions, `zero`, soft min/max, axis breaks, etc. are all preserved.

## Known limitation

The axis space is allocated during layout using the pre-layout tick labels; if re-nicing produces a wider ceiling label, the axis width is not re-measured afterwards. In practice the niced ceiling label width is essentially unchanged, and this matches the trade-off already implied by the existing `TODO`.
