### PR TITLE
[codex] fix duplicated pre-render event listeners

### DIFF
--- a/packages/vchart/__tests__/unit/core/vchart.test.ts
+++ b/packages/vchart/__tests__/unit/core/vchart.test.ts
@@ -7,6 +7,8 @@ import type { IAreaSeriesSpec } from '../../../src/series/area/interface';
 import type { IPoint } from '../../../src/typings';
 import { polarToCartesian } from '@visactor/vutils';
 import type { IMarkGraphic } from '../../../src/mark/interface';
+import type { BaseEventParams } from '../../../src/event/interface';
+import type { IChartSpec } from '../../../src/typings/spec/common';
 
 describe('VChart', () => {
   describe('render and update', () => {
@@ -228,6 +230,46 @@ describe('VChart', () => {
       vchart.updateData('areaData', data);
       vchart.renderSync();
       expect(vchart.getChart()?.getAllSeries()[0].getRawData()?.latestData.length).toBe(data.length);
+    });
+
+    it('does not duplicate user event registered before updateSpec initializes chart', () => {
+      const spec: IBarChartSpec = {
+        type: 'bar',
+        direction: 'horizontal',
+        data: [
+          {
+            id: 'barData',
+            values: [
+              { cat: '类目一', value: 80 },
+              { cat: '类目二', value: 52 }
+            ]
+          }
+        ],
+        yField: 'cat',
+        xField: 'value'
+      };
+      const eventSpy = jest.fn();
+      const emptySpec: IChartSpec = { type: '' };
+      const eventParams: BaseEventParams = {
+        source: 'chart',
+        model: { type: 'bar' } as unknown as BaseEventParams['model'],
+        event: {
+          stopPropagation: jest.fn(),
+          preventDefault: jest.fn()
+        } as unknown as BaseEventParams['event'],
+        item: null as unknown as BaseEventParams['item'],
+        datum: null as unknown as BaseEventParams['datum']
+      };
+
+      vchart = new VChart(emptySpec, {
+        renderCanvas: canvasDom,
+        animation: false
+      });
+      vchart.on('click', { source: 'chart', level: 'model' }, eventSpy);
+      vchart.updateSpecSync(spec);
+      vchart.event.emit('click', eventParams, 'model');
+
+      expect(eventSpy).toBeCalledTimes(1);
     });
 
     it('updateViewBox', async () => {

--- a/packages/vchart/src/core/vchart.ts
+++ b/packages/vchart/src/core/vchart.ts
@@ -453,7 +453,7 @@ export class VChart implements IVChart {
     // 设置全局字体
     this._setFontFamilyTheme(this.getTheme('fontFamily') as string);
     this._initDataSet(this._option.dataSet);
-    this._autoSize = isTrueBrowseEnv ? (spec.autoFit ?? this._option.autoFit ?? true) : false;
+    this._autoSize = isTrueBrowseEnv ? spec.autoFit ?? this._option.autoFit ?? true : false;
     this._bindResizeEvent();
     this._bindViewEvent();
     this._initChartPlugin();
@@ -676,6 +676,8 @@ export class VChart implements IVChart {
   }
 
   protected _reCompile(updateResult: IUpdateSpecResult, morphConfig?: IMorphConfig) {
+    const shouldRestoreUserEvents = updateResult.reMake && !!this._chart;
+
     if (updateResult.reMake) {
       this._releaseData();
       this._initDataSet();
@@ -702,7 +704,9 @@ export class VChart implements IVChart {
       // chart 内部事件 模块自己必须删除
       // 内部模块删除事件时，调用了event Dispatcher.release() 导致用户事件被一起删除
       // 外部事件现在需要重新添加
-      this._userEvents.forEach(e => this._event?.on(e.eType as any, e.query as any, e.handler as any));
+      if (shouldRestoreUserEvents) {
+        this._userEvents.forEach(e => this._event?.on(e.eType as any, e.query as any, e.handler as any));
+      }
     } else if (updateResult.reCompile) {
       // recompile
       // 清除之前的所有 compile 内容
@@ -1477,8 +1481,8 @@ export class VChart implements IVChart {
           isObject(specTheme) && specTheme.type
             ? specTheme.type
             : isObject(optionTheme) && optionTheme.type
-              ? optionTheme.type
-              : this._currentThemeName
+            ? optionTheme.type
+            : this._currentThemeName
         ),
         getThemeObject(optionTheme),
         getThemeObject(specTheme)
@@ -1512,7 +1516,7 @@ export class VChart implements IVChart {
     }
 
     const lasAutoSize = this._autoSize;
-    this._autoSize = isTrueBrowser(this._option.mode) ? (this._spec.autoFit ?? this._option.autoFit ?? true) : false;
+    this._autoSize = isTrueBrowser(this._option.mode) ? this._spec.autoFit ?? this._option.autoFit ?? true : false;
     if (this._autoSize !== lasAutoSize) {
       resize = true;
     }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Release
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 🔗 Related PR link

N/A

### 🐞 Bugserver case id

N/A

### 💡 Background and solution

When a VChart instance is created with an empty initial spec and a user registers a chart/model-level event before calling `updateSpec`, the type change causes the `reMake` path to run before any chart/model has been initialized.

The user callback is already registered in the event dispatcher at that point. The old reMake logic always replayed `_userEvents`, so the same callback was inserted into the event bubble queue twice and one click could trigger the handler twice.

This change only replays `_userEvents` when a prior chart instance existed and its release path could have cleared dispatcher handlers. It preserves the existing replay behavior for real remakes while avoiding duplicate registration for pre-render/updateSpec initialization.

A regression test covers the reported sequence:

```ts
const vc = new VChart({ type: '' }, options);
vc.on('click', { source: 'chart', level: 'model' }, cb);
vc.updateSpecSync(barSpec);
```

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix duplicate chart/model event callbacks when events are registered before `updateSpec` initializes the chart. |
| 🇨🇳 Chinese | 修复在 `updateSpec` 初始化图表前注册 chart/model 事件时，回调被重复触发的问题。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

### 🚀 Summary

- Added a regression test for pre-updateSpec user event registration.
- Skipped `_userEvents` replay when `reMake` runs without a prior chart instance.

### 🔍 Walkthrough

- `packages/vchart/src/core/vchart.ts`: gate user event replay on whether a previous chart existed before reMake release.
- `packages/vchart/__tests__/unit/core/vchart.test.ts`: verify a model-level click callback registered before `updateSpecSync` only fires once.

### ✅ Validation

- `npm test -- __tests__/unit/core/vchart.test.ts --runInBand`
- `npm test -- __tests__/unit/event/event.test.ts --runInBand`
- `npm run compile`
- `npx eslint src/core/vchart.ts __tests__/unit/core/vchart.test.ts` (0 errors; existing warnings)
- pre-push `rush test --only tag:package` (47 vchart suites / 136 tests passed; existing MaxListenersExceededWarning shown)
