### PR TITLE
fix: restore axis grid after visibility update

### DIFF
--- a/common/changes/@visactor/vchart/fix-restore-axis-grid-after-update_2026-07-15.json
+++ b/common/changes/@visactor/vchart/fix-restore-axis-grid-after-update_2026-07-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: restore existing axis grid graphics when grid visibility is enabled again through updateSpec with animation disabled",
+      "type": "patch",
+      "packageName": "@visactor/vchart"
+    }
+  ],
+  "packageName": "@visactor/vchart",
+  "email": "lixuef1313@163.com"
+}

--- a/packages/vchart/__tests__/unit/core/update-effects.test.ts
+++ b/packages/vchart/__tests__/unit/core/update-effects.test.ts
@@ -40,6 +40,7 @@ type TestChartModel = {
   getComponentsByKey: (key: string) => Array<{
     position?: string;
     getOrient?: () => string;
+    getVRenderComponents?: () => TestVRenderGraphic[];
     getScale?: () => { domain: () => unknown[] };
     getTickData?: () => {
       getDataView: () => {
@@ -50,6 +51,15 @@ type TestChartModel = {
   updateDataSpec: () => void;
   updateGlobalScaleDomain: () => void;
   reDataFlow: () => void;
+};
+
+type TestVRenderGraphic = {
+  name?: string;
+  attribute?: {
+    visible?: boolean;
+    visibleAll?: boolean;
+  };
+  forEachChildren?: (cb: (child: TestVRenderGraphic) => void) => void;
 };
 
 const getChartModel = (chart: VChart) => chart.getChart() as unknown as TestChartModel;
@@ -260,6 +270,29 @@ const createAxisElementVisibleSpec = (element: AxisVisibleElement, visible: bool
     }
   ]
 });
+
+const createLineAxisGridVisibleSpec = (gridVisible: boolean, animation: boolean): ILineChartSpec =>
+  ({
+    type: 'line',
+    animation,
+    data: [
+      {
+        id: 'data',
+        values: [
+          { x: 'A', y: 11 },
+          { x: 'B', y: 12 },
+          { x: 'C', y: 23 },
+          { x: 'D', y: 14 }
+        ]
+      }
+    ],
+    xField: 'x',
+    yField: 'y',
+    axes: [
+      { orient: 'left', grid: { visible: gridVisible } },
+      { orient: 'bottom', grid: { visible: gridVisible } }
+    ]
+  } as ILineChartSpec);
 
 const createLegendAppearanceSpec = (
   labelFill: string,
@@ -1282,6 +1315,55 @@ const getAxisTickTransformOptions = (chart: VChart, orient: 'angle' | 'radius') 
   return tickTransform?.options as { startAngle?: number };
 };
 
+const findAxisGridComponent = (chart: VChart, orient: 'left' | 'bottom') => {
+  const axis = getChartModel(chart)
+    .getComponentsByKey('axes')
+    .find(axisItem => axisItem.getOrient?.() === orient);
+
+  return axis?.getVRenderComponents?.()[1];
+};
+
+const getAxisGridComponent = (chart: VChart, orient: 'left' | 'bottom') => {
+  const gridComponent = findAxisGridComponent(chart, orient);
+  expect(gridComponent).toBeDefined();
+
+  return gridComponent as TestVRenderGraphic;
+};
+
+const collectGraphicsByName = (graphic: TestVRenderGraphic, name: string) => {
+  const graphics: TestVRenderGraphic[] = [];
+  const visit = (current: TestVRenderGraphic) => {
+    if (current.name === name) {
+      graphics.push(current);
+    }
+    current.forEachChildren?.(visit);
+  };
+
+  visit(graphic);
+  return graphics;
+};
+
+const expectAxisGridLinesShown = (chart: VChart, orient: 'left' | 'bottom') => {
+  const gridComponent = getAxisGridComponent(chart, orient);
+  const gridLines = collectGraphicsByName(gridComponent, 'axis-grid-line');
+
+  expect(gridComponent.attribute?.visibleAll).not.toBe(false);
+  expect(gridLines.length).toBeGreaterThan(0);
+  gridLines.forEach(gridLine => {
+    expect(gridLine.attribute?.visible).not.toBe(false);
+  });
+};
+
+const expectAxisGridHidden = (chart: VChart, orient: 'left' | 'bottom') => {
+  const gridComponent = findAxisGridComponent(chart, orient);
+
+  if (!gridComponent) {
+    return;
+  }
+
+  expect(gridComponent.attribute?.visibleAll).toBe(false);
+};
+
 const getFirstScatterGraphic = (chart: VChart) => {
   const scatterSeries = chart
     .getChart()
@@ -2191,6 +2273,29 @@ describe('vchart scoped update effects', () => {
       const result = (chart as unknown as VChartInternals)._updateSpec(createAxisElementVisibleSpec('grid', true));
 
       expect(result.reMake).toBe(true);
+    } finally {
+      chart.release();
+    }
+  });
+
+  it('restores existing axis grid lines after animation false hides and shows them', async () => {
+    const chart = new VChart(createLineAxisGridVisibleSpec(true, true), { dom });
+
+    try {
+      chart.renderSync();
+
+      expectAxisGridLinesShown(chart, 'left');
+      expectAxisGridLinesShown(chart, 'bottom');
+
+      await chart.updateSpec(createLineAxisGridVisibleSpec(false, false));
+
+      expectAxisGridHidden(chart, 'left');
+      expectAxisGridHidden(chart, 'bottom');
+
+      await chart.updateSpec(createLineAxisGridVisibleSpec(true, false));
+
+      expectAxisGridLinesShown(chart, 'left');
+      expectAxisGridLinesShown(chart, 'bottom');
     } finally {
       chart.release();
     }

--- a/packages/vchart/src/mark/component.ts
+++ b/packages/vchart/src/mark/component.ts
@@ -190,6 +190,9 @@ export class ComponentMark extends BaseMark<ICommonSpec> implements IComponentMa
       this._component && this._product.appendChild(this._component);
     } else {
       this._component.setAttributes(attrs as any);
+      if (this._product && this._component.parent !== this._product) {
+        this._product.appendChild(this._component);
+      }
     }
 
     if (this._component) {


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Performance optimization
- [x] Test Case

### 💡 Background and solution

在关闭动画时，通过 `updateSpec` 将坐标轴网格的 `visible` 从 `true` 切换为 `false` 再恢复为 `true`，已有的 VRender grid component 可能已经从 product 上脱离。此前 `ComponentMark` 复用已有 component 时只更新 attributes，没有重新挂载，导致网格线无法恢复显示。

本修复在复用 component 时检查其 parent；仅当它已脱离当前 product 时重新 `appendChild`。同时增加左右坐标轴网格显隐切换的回归测试。公共 API 不变，正常已挂载路径不会增加额外生命周期操作。

### 📝 Changelog

| Language | Changelog |
| --- | --- |
| 🇺🇸 English | Restore existing axis grid graphics when visibility is enabled again through `updateSpec` with animation disabled. |
| 🇨🇳 Chinese | 修复关闭动画时通过 `updateSpec` 隐藏并重新显示坐标轴网格后，已有网格图元未恢复的问题。 |

### ☑️ Self-Check before Merge

- [x] Doc is not needed
- [x] Demo is not needed
- [x] TypeScript definition update is not needed
- [x] Changelog is provided

### ✅ Validation

- `rushx test --runInBand __tests__/unit/core/update-effects.test.ts`: 108/108 tests passed
- `rushx compile`: passed
- Pre-push `rush test --only tag:package`: VChart 74 suites / 382 tests passed; VUtils Extension 1/1 test passed
- ESLint on changed TypeScript files: 0 errors
