### PR TITLE
fix: release dimension hover pointerout listener

### DIFF
--- a/common/changes/@visactor/vchart/fix-dimension-hover-event-release_2026-07-17.json
+++ b/common/changes/@visactor/vchart/fix-dimension-hover-event-release_2026-07-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: release the pointerout listener when dimension hover events are unregistered",
+      "type": "patch",
+      "packageName": "@visactor/vchart"
+    }
+  ],
+  "packageName": "@visactor/vchart",
+  "email": "lixuef1313@163.com"
+}

--- a/packages/vchart/__tests__/unit/event/dimension-hover.test.ts
+++ b/packages/vchart/__tests__/unit/event/dimension-hover.test.ts
@@ -1,0 +1,23 @@
+import { DimensionHoverEvent } from '../../../src/event/events/dimension/dimension-hover';
+
+describe('[event] DimensionHoverEvent', () => {
+  test('unregisters every desktop event it registers', () => {
+    const eventDispatcher = {
+      register: jest.fn(),
+      unregister: jest.fn()
+    };
+    const event = new DimensionHoverEvent(eventDispatcher as any, 'desktop-browser');
+
+    event.register('dimensionHover', { callback: jest.fn(), query: {} } as any);
+    event.unregister();
+
+    expect(eventDispatcher.unregister).toHaveBeenCalledWith('pointermove', {
+      query: null,
+      callback: expect.any(Function)
+    });
+    expect(eventDispatcher.unregister).toHaveBeenCalledWith('pointerout', {
+      query: null,
+      callback: expect.any(Function)
+    });
+  });
+});

--- a/packages/vchart/src/event/events/dimension/dimension-hover.ts
+++ b/packages/vchart/src/event/events/dimension/dimension-hover.ts
@@ -35,6 +35,10 @@ export class DimensionHoverEvent extends DimensionEvent {
       query: null,
       callback: this.onMouseMove
     });
+    this._eventDispatcher.unregister('pointerout', {
+      query: null,
+      callback: this.onMouseOut
+    });
 
     if (isMobileLikeMode(this._mode)) {
       // 移动端点按也出发 hover


### PR DESCRIPTION
[[中文版模板 / Chinese template](https://github.com/VisActor/VChart/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Release
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 🔗 Related PR link

Related to #4626.

### 🐞 Bugserver case id

N/A

### 💡 Background and solution

`DimensionHoverEvent` registers `pointermove`, `pointerout`, and, on mobile, `pointerdown`. Its `unregister` method did not remove the `pointerout` listener, so a released dimension-hover subscriber could remain referenced by the dispatcher.

This change unregisters `pointerout` with the same callback and adds a regression test that verifies the desktop listeners are all removed.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed a retained `pointerout` listener after unregistering dimension-hover events. |
| 🇨🇳 Chinese | 修复 dimension hover 事件注销后遗留 `pointerout` 监听的问题。 |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
