### PR TITLE
feat: support dynamic legend pager layout and position

### DIFF
--- a/common/changes/@visactor/vchart/feat-discrete-legend-pager-layout-position-functions_2026-07-22.json
+++ b/common/changes/@visactor/vchart/feat-discrete-legend-pager-layout-position-functions_2026-07-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "feat: support layout-time callbacks for discrete legend pager.layout and pager.position with resolved maxRow and maxCol",
+      "type": "minor",
+      "packageName": "@visactor/vchart"
+    }
+  ],
+  "packageName": "@visactor/vchart",
+  "email": "chendaxin.tk@bytedance.com"
+}

--- a/docs/assets/option/en/component/legend-discrete.md
+++ b/docs/assets/option/en/component/legend-discrete.md
@@ -817,12 +817,20 @@ Set the pager type, currently supporting two styles:
 - Default style: pager with arrows
 - `type: 'scrollbar'`: Scrollbar pager
 
-#### layout(string)
+#### layout(string|Function)
 
 The layout of the page turner, the optional values are `'horizontal'` and `'vertical'`. The default value logic is:
 
 - Defaults to `'vertical'` when legend `orient` is `'left'` or `'right'`.
 - Defaults to `'horizontal'` when legend `orient` is `'top'` or `'bottom'`.
+
+A callback `(ctx) => 'horizontal' | 'vertical'` is also supported. It is evaluated during layout after `maxRow` / `maxCol` have been resolved. `ctx` contains `rect`, `orient`, `id`, `maxRow`, and `maxCol`, so the pager handlers can switch to a vertical arrangement for a multi-row legend.
+
+#### position(string|Function)
+
+The cross-axis alignment of the pager within the legend content. The optional values are `'start'`, `'middle'`, and `'end'`; the default is `'middle'`.
+
+A callback `(ctx) => 'start' | 'middle' | 'end'` is also supported. It is evaluated during layout after `maxRow` / `maxCol` have been resolved and receives the same `ctx` as the `layout` callback, so a multi-row legend can top-align its pager while a single-row legend remains centered.
 
 #### defaultCurrent(number)
 

--- a/docs/assets/option/zh/component/legend-discrete.md
+++ b/docs/assets/option/zh/component/legend-discrete.md
@@ -804,12 +804,20 @@ value: {
 - 默认样式：带箭头的翻页器
 - `type: 'scrollbar'`: 滚动条翻页
 
-#### layout(string)
+#### layout(string|Function)
 
 翻页器的布局方式，可选值为 `'horizontal'` 和 `'vertical'`。默认值逻辑为：
 
 - 图例 `orient` 为 `'left'` 或者 `'right'` 时，默认为 `'vertical'`。
 - 图例 `orient` 为 `'top'` 或者 `'bottom'` 时，默认为 `'horizontal'`。
+
+支持回调 `(ctx) => 'horizontal' | 'vertical'`。回调在布局期、`maxRow` / `maxCol` 求值后执行，`ctx` 包含 `rect`、`orient`、`id`、`maxRow` 和 `maxCol`，可据此让多行图例的翻页按钮切换为上下排列。
+
+#### position(string|Function)
+
+翻页器在图例内容交叉轴方向上的对齐位置，可选值为 `'start'`、`'middle'` 和 `'end'`，默认值为 `'middle'`。
+
+支持回调 `(ctx) => 'start' | 'middle' | 'end'`。回调同样在布局期、`maxRow` / `maxCol` 求值后执行，并接收与 `layout` 回调相同的 `ctx`，可据此让多行图例的翻页器顶对齐、单行图例保持居中。
 
 #### defaultCurrent(number)
 

--- a/packages/vchart/__tests__/unit/component/legend/discrete-legend.test.ts
+++ b/packages/vchart/__tests__/unit/component/legend/discrete-legend.test.ts
@@ -1,6 +1,6 @@
 import { getLegendAttributes } from '../../../../src/component/legend/discrete/util';
 
-describe('Discrete legend getLegendAttributes maxRow/maxCol', () => {
+describe('Discrete legend getLegendAttributes layout callbacks', () => {
   const rect = { width: 200, height: 80 };
 
   test('should evaluate function `maxRow` against the layout rect', () => {
@@ -77,5 +77,78 @@ describe('Discrete legend getLegendAttributes maxRow/maxCol', () => {
     );
 
     expect(received.orient).toBe('bottom');
+  });
+
+  test('should evaluate `pager.layout` after maxRow/maxCol are resolved', () => {
+    let received: any;
+    const attrs = getLegendAttributes(
+      {
+        type: 'discrete',
+        orient: 'bottom',
+        id: 'l3',
+        maxRow: () => 3,
+        maxCol: 1,
+        pager: {
+          layout: (ctx: any) => {
+            received = ctx;
+            return ctx.maxRow > 1 ? 'vertical' : 'horizontal';
+          }
+        }
+      } as any,
+      rect as any,
+      'top'
+    );
+
+    expect(attrs.pager.layout).toBe('vertical');
+    expect(received.rect).toBe(rect);
+    expect(received.orient).toBe('top');
+    expect(received.id).toBe('l3');
+    expect(received.maxRow).toBe(3);
+    expect(received.maxCol).toBe(1);
+  });
+
+  test('should keep a static `pager.layout` unchanged', () => {
+    const attrs = getLegendAttributes(
+      { type: 'discrete', pager: { layout: 'horizontal' } } as any,
+      rect as any
+    );
+
+    expect(attrs.pager.layout).toBe('horizontal');
+  });
+
+  test('should evaluate `pager.position` after maxRow/maxCol are resolved', () => {
+    let received: any;
+    const attrs = getLegendAttributes(
+      {
+        type: 'discrete',
+        orient: 'bottom',
+        id: 'l4',
+        maxRow: () => 3,
+        maxCol: 1,
+        pager: {
+          position: (ctx: any) => {
+            received = ctx;
+            return ctx.maxRow > 1 ? 'start' : 'middle';
+          }
+        }
+      } as any,
+      rect as any
+    );
+
+    expect(attrs.pager.position).toBe('start');
+    expect(received.rect).toBe(rect);
+    expect(received.orient).toBe('bottom');
+    expect(received.id).toBe('l4');
+    expect(received.maxRow).toBe(3);
+    expect(received.maxCol).toBe(1);
+  });
+
+  test('should keep a static `pager.position` unchanged', () => {
+    const attrs = getLegendAttributes(
+      { type: 'discrete', pager: { position: 'middle' } } as any,
+      rect as any
+    );
+
+    expect(attrs.pager.position).toBe('middle');
   });
 });

--- a/packages/vchart/src/component/legend/discrete/interface.ts
+++ b/packages/vchart/src/component/legend/discrete/interface.ts
@@ -156,6 +156,9 @@ export type IItem = {
   autoEllipsisStrategy?: 'labelFirst' | 'valueFirst' | 'none';
 } & Omit<LegendItem, 'background' | 'shape' | 'label' | 'value' | 'focusIconStyle' | 'width' | 'height' | 'maxWidth'>;
 
+export type LegendPagerLayout = 'horizontal' | 'vertical';
+export type LegendPagerPosition = 'start' | 'middle' | 'end';
+
 export type IPager = {
   /**
    * 文本样式配置
@@ -186,7 +189,17 @@ export type IPager = {
       disable?: Omit<NoVisibleMarkStyle<ISymbolMarkSpec>, 'symbolType'>;
     };
   };
-} & Omit<LegendPagerAttributes, 'textStyle' | 'handler'>;
+  /**
+   * The layout of the pager. A callback is evaluated during layout after `maxRow` / `maxCol`
+   * have been resolved, allowing the pager handlers to adapt to a multi-row / multi-column legend.
+   */
+  layout?: LegendPagerLayout | ((ctx: IDiscreteLegendPagerCallbackContext) => LegendPagerLayout);
+  /**
+   * The cross-axis position of the pager. A callback is evaluated during layout after `maxRow` /
+   * `maxCol` have been resolved, allowing the pager alignment to adapt to the resolved page layout.
+   */
+  position?: LegendPagerPosition | ((ctx: IDiscreteLegendPagerCallbackContext) => LegendPagerPosition);
+} & Omit<LegendPagerAttributes, 'textStyle' | 'handler' | 'layout' | 'position'>;
 
 export type ILegendScrollbar = {
   type: 'scrollbar';
@@ -207,6 +220,16 @@ export interface IDiscreteLegendArrangeContext {
   orient: IOrientType;
   /** the id of the legend */
   id?: StringOrNumber;
+}
+
+/**
+ * The layout context passed to `pager.layout` and `pager.position` callbacks.
+ */
+export interface IDiscreteLegendPagerCallbackContext extends IDiscreteLegendArrangeContext {
+  /** the resolved maximum row count, when configured */
+  maxRow?: number;
+  /** the resolved maximum column count, when configured */
+  maxCol?: number;
 }
 
 /**

--- a/packages/vchart/src/component/legend/discrete/util.ts
+++ b/packages/vchart/src/component/legend/discrete/util.ts
@@ -52,13 +52,33 @@ export function getLegendAttributes(spec: IDiscreteLegendSpec, rect: ILayoutRect
   // Use the layout-resolved orient (falling back to the spec orient default rule) so the callback
   // sees the orient the legend actually lays out with, not the raw `spec.orient` which is
   // `undefined` when the user omits it.
-  if (isFunction(attrs.maxRow) || isFunction(attrs.maxCol)) {
+  const pagerLayout = (pager as IPager).layout;
+  const pagerPosition = (pager as IPager).position;
+  if (
+    isFunction(attrs.maxRow) ||
+    isFunction(attrs.maxCol) ||
+    isFunction(pagerLayout) ||
+    isFunction(pagerPosition)
+  ) {
     const resolvedOrient = isValidOrient(layoutOrient) ? layoutOrient : isValidOrient(orient) ? orient : 'left';
     if (isFunction(attrs.maxRow)) {
       attrs.maxRow = attrs.maxRow({ rect, orient: resolvedOrient, id });
     }
     if (isFunction(attrs.maxCol)) {
       attrs.maxCol = attrs.maxCol({ rect, orient: resolvedOrient, id });
+    }
+    const pagerContext = {
+      rect,
+      orient: resolvedOrient,
+      id,
+      maxRow: attrs.maxRow,
+      maxCol: attrs.maxCol
+    };
+    if ((pager as ILegendScrollbar).type !== 'scrollbar' && isFunction(pagerLayout)) {
+      (pager as IPager).layout = pagerLayout(pagerContext);
+    }
+    if ((pager as ILegendScrollbar).type !== 'scrollbar' && isFunction(pagerPosition)) {
+      (pager as IPager).position = pagerPosition(pagerContext);
     }
   }
 


### PR DESCRIPTION
## Summary

- allow `pager.layout` and `pager.position` to be configured as layout-time callbacks
- evaluate both callbacks after dynamic `maxRow` / `maxCol` have been resolved
- expose `rect`, resolved `orient`, legend `id`, `maxRow`, and `maxCol` through a shared callback context
- preserve existing static string configurations and scrollbar behavior
- document the callback API in English and Chinese

## Motivation

Multi-row discrete legends may need vertically arranged pager handlers aligned to the first row, while single-row legends should retain a horizontal, centered pager. Resolving these values during layout lets the pager follow responsive row and column counts.

## Validation

- discrete legend callback unit coverage for dynamic and static `layout` / `position`
- verified callback order after `maxRow` / `maxCol` resolution
- verified resize transitions between single-row and multi-row results
- verified generated CJS, ESM, and public TypeScript declarations
- downstream split-render acceptance completed with a real multi-row legend