### PR TITLE
fix: respect disabled label smart invert

### DIFF
--- a/common/changes/@visactor/vchart/fix-issue-4492-label-smart-invert_2026-08-04.json
+++ b/common/changes/@visactor/vchart/fix-issue-4492-label-smart-invert_2026-08-04.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "fix: respect explicit label smart invert settings",
+      "type": "patch",
+      "packageName": "@visactor/vchart"
+    }
+  ],
+  "packageName": "@visactor/vchart",
+  "email": "biukam.w@gmail.com"
+}

--- a/packages/vchart/__tests__/unit/component/label/label-util.test.ts
+++ b/packages/vchart/__tests__/unit/component/label/label-util.test.ts
@@ -1,0 +1,45 @@
+import { barLabel, pieLabel } from '../../../../src/component/label/util';
+
+const createLabelInfo = (labelSpec: Record<string, unknown>) =>
+  ({
+    labelSpec,
+    series: {
+      direction: 'vertical',
+      getMeasureField: () => ['value'],
+      getYAxisHelper: (): undefined => undefined
+    }
+  } as any);
+
+describe('label util', () => {
+  describe('barLabel', () => {
+    it('preserves disabled smart invert for inside labels', () => {
+      const result = barLabel(createLabelInfo({ position: 'inside', smartInvert: false }));
+
+      expect(result.smartInvert).toBe(false);
+    });
+
+    it('preserves explicit smart invert options for inside labels', () => {
+      const smartInvert = {
+        fillStrategy: 'invertBase',
+        strokeStrategy: 'similarBase'
+      };
+      const result = barLabel(createLabelInfo({ position: 'inside', smartInvert }));
+
+      expect(result.smartInvert).toBe(smartInvert);
+    });
+
+    it('enables smart invert by default for inside labels', () => {
+      const result = barLabel(createLabelInfo({ position: 'inside' }));
+
+      expect(result.smartInvert).toBe(true);
+    });
+  });
+
+  describe('pieLabel', () => {
+    it('preserves disabled smart invert for inside labels', () => {
+      const result = pieLabel(createLabelInfo({ position: 'inside', smartInvert: false }));
+
+      expect(result.smartInvert).toBe(false);
+    });
+  });
+});

--- a/packages/vchart/src/component/label/util.ts
+++ b/packages/vchart/src/component/label/util.ts
@@ -173,10 +173,7 @@ export function barLabel(labelInfo: ILabelInfo) {
   }
 
   // encode smartInvert
-  let smartInvert = false;
-  if (isString(originPosition) && originPosition.includes('inside')) {
-    smartInvert = true;
-  }
+  const smartInvert = labelSpec.smartInvert ?? (isString(originPosition) && originPosition.includes('inside'));
 
   return { position, overlap, smartInvert };
 }
@@ -240,12 +237,7 @@ export function pieLabel(labelInfo: ILabelInfo) {
   const position = labelPosition as BaseLabelAttrs['position'];
 
   // encode smartInvert
-  let smartInvert;
-  if (labelSpec.smartInvert) {
-    smartInvert = labelSpec.smartInvert;
-  } else {
-    smartInvert = isString(labelPosition) && labelPosition.includes('inside');
-  }
+  const smartInvert = labelSpec.smartInvert ?? (isString(labelPosition) && labelPosition.includes('inside'));
 
   return { position, smartInvert };
 }


### PR DESCRIPTION
### 🤔 这个分支是...

- [ ] 新功能
- [x] Bug fix
- [ ] Ts 类型更新
- [ ] 打包优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 重构
- [ ] 依赖版本更新
- [ ] 代码优化
- [x] 测试 case 更新
- [ ] 分支合并
- [ ] 发布
- [ ] 网站/文档更新
- [ ] demo 更新
- [ ] Workflow
- [ ] 其他 (具体是什么，请补充?)

### 🔗 相关 issue 链接

Fix #4492

### 🔗 相关的 PR 链接

N/A

### 🐞 Bugserver 用例 id

N/A

### 💡 问题的背景&解决方案

内部 bar 和 pie 标签会根据 `position` 自动开启 `smartInvert`，但现有归一化逻辑会覆盖显式配置的 `smartInvert: false`，bar 标签还会覆盖显式传入的 options 对象。

本次修改仅在 `smartInvert` 未配置时使用内部标签的自动反色默认值，从而保留显式的布尔值或 options 对象。同时补充单元测试，覆盖关闭自动反色、保留 options 对象以及未配置时维持原有默认行为。

### 📝 Changelog

| Language   | Changelog                                                         |
| ---------- | ----------------------------------------------------------------- |
| 🇺🇸 English | Respect explicit smart invert settings for bar and pie labels.    |
| 🇨🇳 Chinese | 修复 bar 和 pie 标签显式 smartInvert 配置被自动默认值覆盖的问题。 |

### ☑️ 自测

⚠️ 在提交 PR 之前，请检查一下内容. ⚠️

- [x] 文档提供了，或者更新，或者不需要
- [x] Demo 提供了，或者更新，或者不需要
- [x] Ts 类型定义提供了，或者更新，或者不需要
- [x] Changelog 提供了，或者不需要

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
