### PR TITLE
fix: prevent XSS in tooltip title

### DIFF
--- a/packages/vchart/__tests__/unit/component/tooltip/dom-tooltip-handler.test.ts
+++ b/packages/vchart/__tests__/unit/component/tooltip/dom-tooltip-handler.test.ts
@@ -1,5 +1,8 @@
 import { DomTooltipHandler } from '../../../../src/plugin/components/tooltip-handler/dom-tooltip-handler';
-import { TOOLTIP_CONTAINER_EL_CLASS_NAME } from '../../../../src/plugin/components/tooltip-handler/constants';
+import {
+  TOOLTIP_CONTAINER_EL_CLASS_NAME,
+  TOOLTIP_TITLE_CLASS_NAME
+} from '../../../../src/plugin/components/tooltip-handler/constants';
 import { createDiv, removeDom } from '../../../util/dom';
 
 const createTooltipSpec = (spec: any) => ({
@@ -60,5 +63,17 @@ describe('DomTooltipHandler', () => {
     handler.initEl();
 
     expect(parentElement.querySelector(`.${TOOLTIP_CONTAINER_EL_CLASS_NAME}`)).toBe(handler.getTooltipContainer());
+  });
+
+  it('renders title as text', () => {
+    const handler = createHandler({}, container) as any;
+    const title = '<img src=x onerror="alert(1)">';
+
+    handler.initRootDom();
+    handler._updateDomStringByCol({ title: { value: title }, content: [] });
+
+    const titleDom = container.querySelector(`.${TOOLTIP_TITLE_CLASS_NAME}`);
+    expect(titleDom.textContent).toBe(title);
+    expect(titleDom.querySelector('img')).toBeNull();
   });
 });

--- a/packages/vchart/src/plugin/components/tooltip-handler/dom-tooltip-handler.ts
+++ b/packages/vchart/src/plugin/components/tooltip-handler/dom-tooltip-handler.ts
@@ -252,7 +252,7 @@ export class DomTooltipHandler extends BaseTooltipHandler {
         ...(hasContent ? rowStyle : { marginBottom: '0px' }),
         marginTop: '0px'
       });
-      (titleDom.firstChild as HTMLElement).innerHTML = `${title.value ?? ''}`;
+      (titleDom.firstChild as HTMLElement).textContent = `${title.value ?? ''}`;
     } else if (titleDom && title.visible === false) {
       titleDom.parentNode.removeChild(titleDom);
     }


### PR DESCRIPTION
## 修改内容

- DOM tooltip title 改用 `textContent`，不再将 title 直接写入 `innerHTML`
- 增加恶意 `<img onerror>` title 不会生成 DOM 节点的回归测试

## 原因与影响

默认 DOM tooltip handler 直接把可由用户 spec 提供的 title 写入 `innerHTML`，攻击者可借此注入可执行 HTML。修复后 title 默认按纯文本渲染，不影响 `updateElement` 自定义 DOM 能力。

## 验证

- `jest __tests__/unit/component/tooltip/dom-tooltip-handler.test.ts --runInBand`
- `tsc --noEmit --pretty false`
- `eslint src/plugin/components/tooltip-handler/dom-tooltip-handler.ts __tests__/unit/component/tooltip/dom-tooltip-handler.test.ts`
- pre-push `rush test --only tag:package`：77 个测试套件、399 个测试通过
