### PR TITLE
fix: keep crosshair visible for explicitly bound band axes

### DIFF
--- a/common/changes/@visactor/vchart/fix-crosshair-binding-axes_20260807.json
+++ b/common/changes/@visactor/vchart/fix-crosshair-binding-axes_20260807.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vchart",
+      "comment": "fix: preserve crosshair visibility for explicitly bound multiple band axes (Issue #4127)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@visactor/vchart",
+  "email": "biukam.w@gmail.com"
+}

--- a/packages/vchart/__tests__/unit/core/vchart-event.test.ts
+++ b/packages/vchart/__tests__/unit/core/vchart-event.test.ts
@@ -38,6 +38,8 @@ type StageEventListener = {
 };
 
 type CrosshairStateForTest = {
+  enable?: boolean;
+  _layoutCrosshair?: (x: number, y: number) => void;
   _stateByField?: {
     xField?: {
       currentValue?: Map<unknown, unknown>;
@@ -520,6 +522,69 @@ describe('vchart event test', () => {
 
     lineChart.release();
     removeDom(lineContainer);
+  });
+
+  it('should keep crosshair enabled when bound to top and bottom band axes', () => {
+    const crosshairContainer = createDiv();
+    const crosshairDom = createDiv(crosshairContainer);
+    crosshairDom.id = 'multiple-crosshair-axis-container';
+    crosshairContainer.style.position = 'fixed';
+    crosshairContainer.style.width = '500px';
+    crosshairContainer.style.height = '500px';
+    crosshairContainer.style.top = '0px';
+    crosshairContainer.style.left = '0px';
+
+    const chart = new VChart(
+      {
+        type: 'common',
+        data: {
+          id: 'data',
+          values: [
+            { x: 'Mon', type: 'Breakfast', y: 15 },
+            { x: 'Mon', type: 'Lunch', y: 25 },
+            { x: 'Tue', type: 'Breakfast', y: 12 },
+            { x: 'Tue', type: 'Lunch', y: 30 }
+          ]
+        },
+        series: [
+          {
+            type: 'bar',
+            dataId: 'data',
+            xField: ['x', 'type'],
+            yField: 'y',
+            seriesField: 'type'
+          }
+        ],
+        axes: [
+          { orient: 'left' },
+          { orient: 'bottom', type: 'band' },
+          { orient: 'top', type: 'band' },
+          { orient: 'top', type: 'band' }
+        ],
+        crosshair: {
+          xField: {
+            visible: true,
+            bindingAxesIndex: [1, 2]
+          }
+        }
+      } as ICommonChartSpec,
+      { dom: crosshairDom, animation: false }
+    );
+
+    try {
+      chart.renderSync();
+      const crosshair = chart.getComponents().find(component => component.type === 'cartesianCrosshair') as
+        | CrosshairStateForTest
+        | undefined;
+
+      crosshair?._layoutCrosshair?.(250, 250);
+
+      expect(crosshair?.enable).toBe(true);
+      expect(Array.from(crosshair?._stateByField?.xField?.currentValue?.keys() ?? [])).toEqual([1, 2]);
+    } finally {
+      chart.release();
+      removeDom(crosshairContainer);
+    }
   });
 
   it('should fire tooltipRelease before release chart', () => {

--- a/packages/vchart/src/component/crosshair/base.ts
+++ b/packages/vchart/src/component/crosshair/base.ts
@@ -106,17 +106,23 @@ export abstract class BaseCrossHair<T extends ICartesianCrosshairSpec | IPolarCr
    * @returns
    */
   protected _setAllAxisValues(axisMap: IAxisInfo<IAxis>, point: IPoint, field: string): boolean {
-    // 首先不能存在两个离散轴
+    // 未显式绑定轴时，同方向的多个离散轴无法确定唯一的维度位置；显式绑定表示调用方已选择这些轴。
     let discrete = false;
+    let multipleDiscreteAxes = false;
+    const bindingAxesIndex = get(this._spec, `${field}.bindingAxesIndex`);
+    const hasExplicitBinding = isArray(bindingAxesIndex) && bindingAxesIndex.length > 0;
     axisMap.forEach(item => {
       if (isDiscrete(item.axis.getScale().type)) {
         if (!discrete) {
           discrete = true;
         } else {
-          this.enable = false;
+          multipleDiscreteAxes = true;
         }
       }
     });
+    if (multipleDiscreteAxes && !hasExplicitBinding) {
+      this.enable = false;
+    }
     if (!this.enable) {
       return false;
     }


### PR DESCRIPTION
### 🤔 这个分支是...

- [ ] 新功能
- [x] Bug fix
- [ ] Ts 类型更新
- [ ] 打包优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 重构
- [ ] 依赖版本更新
- [ ] 代码优化
- [x] 测试 case 更新
- [ ] 分支合并
- [ ] 发布
- [ ] 网站/文档更新
- [ ] demo 更新
- [ ] Workflow
- [ ] 其他 (具体是什么，请补充?)

### 🔗 相关 issue 链接

Fix #4127

[Issue #4127](https://github.com/VisActor/VChart/issues/4127)

### 🔗 相关的 PR 链接

N/A

### 🐞 Bugserver 用例 id

N/A

### 💡 问题的背景&解决方案

在 common chart 中同时配置 bottom 和 top 两个 band 轴，并通过：

```ts
crosshair: {
  xField: {
    visible: true,
    bindingAxesIndex: [1, 2]
  }
}
```

显式绑定多个离散轴时，crosshair 无法显示。

问题原因是 `_setAllAxisValues` 原先只要检测到同方向存在多个离散轴，就会将 crosshair 的 `enable` 设置为 `false`，没有区分用户是否已经通过 `bindingAxesIndex` 明确选择了轴。

本次修改：

1. 仅在未显式绑定轴时保留多个离散轴的歧义保护。
2. 当存在有效的 `bindingAxesIndex` 时，允许 crosshair 同时处理多个明确绑定的 band 轴。
3. 增加回归测试，验证显式绑定的轴索引为 `[1, 2]`，且未绑定的同向轴不会被处理。

未修改公开 API 和 TypeScript 类型定义；未显式绑定多个离散轴时仍保持原有行为。

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Keep crosshair visible when multiple band axes are explicitly selected with `bindingAxesIndex`. |
| 🇨🇳 Chinese | 修复通过 `bindingAxesIndex` 显式绑定多个 band 轴时 crosshair 消失的问题。 |

### ☑️ 自测

⚠️ 在提交 PR 之前，请检查一下内容. ⚠️

- [x] 文档提供了，或者更新，或者不需要
- [x] Demo 提供了，或者更新，或者不需要
- [x] Ts 类型定义提供了，或者更新，或者不需要
- [x] Changelog 提供了，或者不需要

### ✅ 验证结果

- `pnpm --filter @visactor/vchart exec jest __tests__/unit/core/vchart-event.test.ts --runInBand`
  - 1 个测试套件通过，19 个测试通过
- `pnpm --filter @visactor/vchart run compile`
  - TypeScript 编译通过
- `node common/scripts/install-run-rush.js run -p @visactor/vchart -s build:cjs`
  - CJS 构建通过
- `node common/scripts/install-run-rush.js test -t @visactor/vchart`
  - 76 个测试套件通过，398 个测试通过
- 变更文件格式、Prettier、ESLint 和 `git diff --check` 均通过

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough