### PR TITLE
fix: preserve final attributes for exit animations

### DIFF
--- a/common/changes/@visactor/vchart/fix-grow-height-exit-final-attrs_2026-08-20.json
+++ b/common/changes/@visactor/vchart/fix-grow-height-exit-final-attrs_2026-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vchart",
+      "comment": "fix: preserve final attributes for exit animations when appear animations are disabled",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@visactor/vchart",
+  "email": "skie1997@outlook.com"
+}

--- a/packages/vchart/__tests__/unit/animation/manual-ticker.test.ts
+++ b/packages/vchart/__tests__/unit/animation/manual-ticker.test.ts
@@ -1583,6 +1583,56 @@ describe('manual ticker animation regressions', () => {
     }
   });
 
+  it('keeps bar final attributes for exit animation when appear animation is disabled', () => {
+    const { container, dom } = createChartContainer();
+    const ticker = createManualTicker();
+    const chart = new VChart(
+      {
+        type: 'bar',
+        width: 400,
+        height: 300,
+        data: [
+          {
+            id: 'barData',
+            values: [{ category: 'A', value: 10 }]
+          }
+        ],
+        dataKey: 'category',
+        xField: 'category',
+        yField: 'value',
+        axes: [
+          { orient: 'left', visible: false },
+          { orient: 'bottom', visible: false }
+        ],
+        animationAppear: false
+      } as IBarChartSpec,
+      {
+        dom,
+        ticker,
+        animation: true
+      }
+    );
+
+    chart.renderSync();
+
+    try {
+      const exitingBar = getBarGraphics(chart)[0];
+      const expectedFinalY = exitingBar.context.finalAttrs.y;
+      const expectedFinalY1 = exitingBar.context.finalAttrs.y1;
+
+      expect(() => {
+        chart.updateDataSync('barData', [{ category: 'B', value: 20 }]);
+      }).not.toThrow();
+      expect(exitingBar.context.diffState).toBe('exit');
+      expectClose(getGraphicFinalAttribute(exitingBar).y, expectedFinalY);
+      expectClose(getGraphicFinalAttribute(exitingBar).y1, expectedFinalY1);
+    } finally {
+      chart.release();
+      ticker.release();
+      removeDom(container);
+    }
+  });
+
   it('keeps horizontal bar sorted update final y at the reordered axis positions', () => {
     const { container, dom } = createChartContainer();
     const ticker = createManualTicker();

--- a/packages/vchart/src/mark/base/base-mark.ts
+++ b/packages/vchart/src/mark/base/base-mark.ts
@@ -1410,6 +1410,8 @@ export class BaseMark<T extends ICommonSpec> extends GrammarItem implements IMar
           diffState,
           // 从旧context中继承
           reusing: g.context?.reusing,
+          // exit图元不会再次执行encoder，需要保留上一轮的最终属性用于退场动画
+          finalAttrs: g.context?.finalAttrs,
           // 从旧context中继承
           originalFieldX: g.context?.originalFieldX,
           // 从旧context中继承


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/VisActor/VChart/blob/main/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Release
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

<!--
1. Put the related issue or discussion links here.
2. close #xxxx or fix #xxxx for instance.
-->

### 🔗 Related PR link

<!-- Put the related PR links here. -->

### 🐞 Bugserver case id

<!-- paste the `fileid` field in the bugserver case url -->

### 💡 问题背景与修复方案

#### 问题背景

当配置 `animationAppear: false`、同时保留默认退场动画时，如果将柱状图数据整体替换为一组不同的 key，退场动画执行期间会抛出以下异常：

```text
TypeError: Cannot read properties of undefined (reading 'y')
    at growHeightOutIndividual
```

异常由以下生命周期触发：

1. 初始入场动画被关闭，VRender 不会通过入场动画初始化图元的 `finalAttribute`。
2. 数据更新后，旧柱图图元进入 exit 状态。
3. VChart 为退场图元重建 `context` 时，丢失了上一轮的 `finalAttrs` 属性快照。
4. 退场图元不会再次执行 encoder，因此 `AnimateExecutor` 在执行 `growHeightOut` 前没有可同步的最终属性；随后读取 `graphic.getFinalAttribute().y` 时触发异常。

因此，该问题并非业务数据缺少 `yField` 或数据内容非法，而是 VChart 图元 diff 与退场动画之间的生命周期契约问题。

#### 修复方案

在 mark 数据 diff 重建图元 `context` 时，保留上一轮的 `context.finalAttrs`。仍处于活动状态的 enter/update 图元会在后续 encoder 阶段覆盖这份快照；exit 图元则可以保留最后一次有效的编码属性，供退场动画使用。

该修复继续沿用已有的 `context.finalAttrs -> setFinalAttributes -> growHeightOut` 标准链路，无需在 VRender 的逐图元动画热路径中增加宽泛的运行时兜底。

#### 验证结果

- 新增回归测试，覆盖 `animationAppear: false`、保留默认退场动画以及柱图数据 key 全量替换的场景。
- 验证该测试在修复前能够复现 `undefined.y` 异常，修复后正常通过。
- VChart package pre-push 测试通过：76 个 test suite、399 个测试全部通过。
- TypeScript 编译检查通过。

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |           |
| 🇨🇳 Chinese |           |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] TypeScript definition is updated/provided or not needed
- [ ] Changelog is provided or not needed

---

<!--
Below are template for copilot to generate CR message.
Please DO NOT modify it.
-->

### 🚀 Summary

copilot:summary

### 🔍 Walkthrough

copilot:walkthrough
