### PR TITLE
fix: propagate rush run failures

### DIFF
--- a/common/autoinstallers/run-script/package.json
+++ b/common/autoinstallers/run-script/package.json
@@ -2,6 +2,9 @@
   "name": "run-script",
   "version": "0.0.1",
   "private": true,
+  "scripts": {
+    "test": "node --test --require ts-node/register run.test.ts"
+  },
   "dependencies": {
     "@microsoft/rush-lib": "5.148.0",
     "minimist": "1.2.8",

--- a/common/autoinstallers/run-script/run.test.ts
+++ b/common/autoinstallers/run-script/run.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { execSync } from 'child_process';
+import { run } from './run';
+
+test('throws when the project cannot be found', () => {
+  assert.throws(
+    () => run(['--project', 'missing-project', '--script', 'test']),
+    /Cannot find Rush project: missing-project/
+  );
+});
+
+test('propagates delegated script failures', () => {
+  const scriptError = new Error('script failed');
+  const fail: typeof execSync = () => {
+    throw scriptError;
+  };
+
+  assert.throws(
+    () => run(['--project', '@visactor/vchart', '--script', 'test'], fail),
+    error => error === scriptError
+  );
+});

--- a/common/autoinstallers/run-script/run.ts
+++ b/common/autoinstallers/run-script/run.ts
@@ -7,24 +7,29 @@ interface RunScriptArgv extends ParsedArgs {
   script?: string;
 }
 
-function run() {
-  const argv: RunScriptArgv = minimist(process.argv.slice(2));
+export function run(args = process.argv.slice(2), execute: typeof execSync = execSync) {
+  const argv: RunScriptArgv = minimist(args);
+
+  if (!argv.project || !argv.script) {
+    throw new Error('Both --project and --script are required.');
+  }
+
   const projects = RushConfiguration.loadFromDefaultLocation({
     startingFolder: process.cwd()
   });
 
-  const targetProject = projects.findProjectByShorthandName(argv.project!);
+  const targetProject = projects.findProjectByShorthandName(argv.project);
 
-  if (targetProject) {
-    try {
-      execSync(`rushx ${argv.script}`, {
-        cwd: targetProject?.projectFolder,
-        stdio: [0, 1, 2]
-      });
-    } catch (e) {
-      console.error(`Encountered error: ${e}`);
-    }
+  if (!targetProject) {
+    throw new Error(`Cannot find Rush project: ${argv.project}`);
   }
+
+  execute(`rushx ${argv.script}`, {
+    cwd: targetProject.projectFolder,
+    stdio: [0, 1, 2]
+  });
 }
 
-run();
+if (require.main === module) {
+  run();
+}


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [x] Test Case
- [ ] Branch merge
- [ ] Release
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Other

### 🔗 Related issue link

Fixes #4651

### 🔗 Related PR link

N/A

### 🐞 Bugserver case id

N/A

### 💡 Background and solution

`rush run` delegates to `rushx` through `common/autoinstallers/run-script/run.ts`. The wrapper caught `execSync` failures and only logged them, so the outer Rush command exited successfully even when the project script failed. Unknown project names also completed without an error.

This change lets delegated failures propagate naturally, validates the required arguments and selected project, and keeps the entry point importable for regression tests. It does not change any package API or dependency.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Make `rush run` fail when its project is missing or its delegated script fails. |
| 🇨🇳 Chinese | 当项目不存在或委托脚本失败时，让 `rush run` 正确返回失败。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### Verification

- `npm test --prefix common/autoinstallers/run-script` — 2 tests passed
- `npx --prefix common/autoinstallers/run-script tsc --project common/autoinstallers/run-script/tsconfig.json` — passed
- Prettier 2.6.1 check for the three changed files — passed
- Missing delegated script integration check — outer exit code 1
- Missing project integration check — outer exit code 1
- `rush test --only tag:package` — 393/393 VChart tests passed, but the overall command remained nonzero because an existing `vchart-extension` TypeScript build/link failure produced one failed suite in this local workspace