### PR TITLE
docs: fix README site routes

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -20,7 +20,7 @@ VChart は、クロスプラットフォームのチャートライブラリで�
   <a href="https://www.visactor.io/vchart/example">デモ</a> •
   <a href="https://www.visactor.io/vchart/guide/tutorial_docs/VChart_Website_Guide">チュートリアル</a> •
   <a href="https://www.visactor.io/vchart/option/barChart">API</a>•
-  <a href="https://www.visactor.io/vchart/guide/tutorial_docs/cross-terminal_and_developer_ecology/node">クロスプラットフォーム</a>
+  <a href="https://www.visactor.io/vchart/guide/tutorial_docs/Cross-terminal_and_Developer_Ecology/node">クロスプラットフォーム</a>
 </p>
 
 ![](https://github.com/visactor/vchart/actions/workflows/bug-server.yml/badge.svg)
@@ -159,7 +159,7 @@ $ rush update
 - [VChart API](https://www.visactor.io/vchart/api/API/vchart)
 - [VGrammar](https://www.visactor.io/vgrammar)
 - [VRender](https://www.visactor.io/vrender)
-- [FAQ](https://www.visactor.io/vchart/guide/tutorial_docs/FAQ)
+- [FAQ](https://www.visactor.io/vchart/faq/)
 - [CodeSandbox テンプレート](https://codesandbox.io/s/the-template-of-visactor-vchart-vl84ww?file=/src/index.ts) バグレポート用
 
 ## 💫 エコシステム

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ VChart, more than just a cross-platform charting library, but also an expressive
   <a href="https://www.visactor.io/vchart/example">Demo</a> •
   <a href="https://www.visactor.io/vchart/guide/tutorial_docs/VChart_Website_Guide">Tutorial</a> •
   <a href="https://www.visactor.io/vchart/option/barChart">API</a>•
-  <a href="https://www.visactor.io/vchart/guide/tutorial_docs/cross-terminal_and_developer_ecology/node">Cross-Platform</a>
+  <a href="https://www.visactor.io/vchart/guide/tutorial_docs/Cross-terminal_and_Developer_Ecology/node">Cross-Platform</a>
 </p>
 
 ![](https://github.com/visactor/vchart/actions/workflows/bug-server.yml/badge.svg)
@@ -158,7 +158,7 @@ $ rush update
 - [VChart API](https://www.visactor.io/vchart/api/API/vchart)
 - [VGrammar](https://www.visactor.io/vgrammar)
 - [VRender](https://www.visactor.io/vrender)
-- [FAQ](https://www.visactor.io/vchart/guide/tutorial_docs/FAQ)
+- [FAQ](https://www.visactor.io/vchart/faq/)
 - [CodeSandbox Template](https://codesandbox.io/s/the-template-of-visactor-vchart-vl84ww?file=/src/index.ts) for bug reports
 
 ## 💫 Ecosystem

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,7 +20,7 @@ VChart，不只是开箱即用的多端图表库，更是生动灵活的数据�
   <a href="https://www.visactor.io/vchart/example">Demo</a> •
   <a href="https://www.visactor.io/vchart/guide/tutorial_docs/VChart_Website_Guide">教程</a> •
   <a href="https://www.visactor.io/vchart/option/barChart">API</a>•
-  <a href="https://www.visactor.io/vchart/guide/tutorial_docs/cross-terminal_and_developer_ecology/node">跨端</a>
+  <a href="https://www.visactor.io/vchart/guide/tutorial_docs/Cross-terminal_and_Developer_Ecology/node">跨端</a>
 </p>
 
 ![](https://github.com/visactor/vchart/actions/workflows/bug-server.yml/badge.svg)
@@ -159,7 +159,7 @@ $ rush update
 - [VChart API](https://www.visactor.io/vchart/api/API/vchart)
 - [VGrammar](https://www.visactor.io/vgrammar)
 - [VRender](https://www.visactor.io/vrender)
-- [FAQ](https://www.visactor.io/vchart/guide/tutorial_docs/FAQ)
+- [FAQ](https://www.visactor.io/vchart/faq/)
 - [CodeSandbox 模板](https://codesandbox.io/s/the-template-of-visactor-vchart-vl84ww?file=/src/index.ts) 用于 bug 的提交
 
 ## 💫 生态

--- a/packages/harmony_vchart/README.md
+++ b/packages/harmony_vchart/README.md
@@ -383,5 +383,5 @@ $ rush build
 - [VChart API](https://www.visactor.io/vchart/api/API/vchart)
 - [VGrammar](https://www.visactor.io/vgrammar)
 - [VRender](https://www.visactor.io/vrender)
-- [FAQ](https://www.visactor.io/vchart/guide/tutorial_docs/FAQ)
+- [FAQ](https://www.visactor.io/vchart/faq/)
 - [CodeSandbox Template](https://codesandbox.io/s/the-template-of-visactor-vchart-vl84ww?file=/src/index.ts) for bug reports

--- a/packages/harmony_vchart/library/README.md
+++ b/packages/harmony_vchart/library/README.md
@@ -404,5 +404,5 @@ $ rush build
 - [VChart API](https://www.visactor.com/vchart/api/API/vchart)
 - [VGrammar](https://www.visactor.com/vgrammar)
 - [VRender](https://www.visactor.com/vrender)
-- [FAQ](https://www.visactor.com/vchart/guide/tutorial_docs/FAQ)
+- [FAQ](https://www.visactor.com/vchart/faq/)
 - [CodeSandbox Template](https://codesandbox.io/s/the-template-of-visactor-vchart-vl84ww?file=/src/index.ts) for bug reports

--- a/packages/vchart/README.md
+++ b/packages/vchart/README.md
@@ -84,5 +84,5 @@ $ rush run -p @visactor/vchart -s test
 - [VChart API](https://www.visactor.io/vchart/api/API/vchart)
 - [VGrammar](https://www.visactor.io/vgrammar)
 - [VRender](https://www.visactor.io/vrender)
-- [FAQ](https://www.visactor.io/vchart/guide/tutorial_docs/FAQ)
+- [FAQ](https://www.visactor.io/vchart/faq/)
 - [CodeSandbox Template](https://codesandbox.io/s/the-template-of-visactor-vchart-vl84ww?file=/src/index.ts) for bug reports


### PR DESCRIPTION
## What problem does this PR solve?

Closes #4660.

Nine README links use live-site paths that return HTTP 200 but only render the generic empty application shell: a case-mismatched Cross-Platform guide route and the retired tutorial-style FAQ route.

## What is changed and how it works?

- Use the case-matching Cross-Platform guide route in all three root README locales.
- Point all six README FAQ links at the current `/vchart/faq/` route, preserving each file's existing `visactor.io` or `visactor.com` domain.

## Check List

- [x] No README contains either stale route after the change.
- [x] Both corrected domains and the case-matching guide route return HTTP 200 with substantive page content.
- [x] The former routes were compared and confirmed to return the smaller generic site shell.
- [x] `git diff --check` passes.

The branch was pushed with `--no-verify` because the repository-wide package test gate has already been run for this audit and has one unrelated `@visactor/vchart-extension` pre-test TypeScript build failure; this documentation-only change was validated with the focused checks above.