### PR TITLE
fix: unregister array trigger events on release

### DIFF
--- a/common/changes/@visactor/vchart/fix-issue-4654-array-trigger-release_2026-08-31.json
+++ b/common/changes/@visactor/vchart/fix-issue-4654-array-trigger-release_2026-08-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vchart",
+      "comment": "fix: unregister array-valued trigger event listeners on release",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@visactor/vchart",
+  "email": "biukam.w@gmail.com"
+}

--- a/packages/vchart/__tests__/unit/interaction/base-trigger.test.ts
+++ b/packages/vchart/__tests__/unit/interaction/base-trigger.test.ts
@@ -1,0 +1,29 @@
+import { BaseTrigger } from '../../../src/interaction/triggers/base';
+import type { IBaseTriggerOptions, ITriggerEventHandler } from '../../../src/interaction/interface/trigger';
+import type { IInteraction } from '../../../src/interaction/interface/common';
+
+describe('BaseTrigger', () => {
+  it('unregisters every event in an array when released', () => {
+    const handler = jest.fn();
+    const event = {
+      on: jest.fn(),
+      off: jest.fn(),
+      emit: jest.fn()
+    };
+    const trigger = new (class extends BaseTrigger<IBaseTriggerOptions> {
+      protected getEvents(): Array<{ type: string | string[]; handler: ITriggerEventHandler }> {
+        return [{ type: ['pointerdown', 'pointerup'], handler }];
+      }
+    })({ event, interaction: {} as IInteraction });
+
+    trigger.init();
+    event.on.mockClear();
+    event.off.mockClear();
+
+    trigger.release();
+
+    expect(event.on).not.toHaveBeenCalled();
+    expect(event.off).toHaveBeenNthCalledWith(1, 'pointerdown', handler);
+    expect(event.off).toHaveBeenNthCalledWith(2, 'pointerup', handler);
+  });
+});

--- a/packages/vchart/src/interaction/triggers/base.ts
+++ b/packages/vchart/src/interaction/triggers/base.ts
@@ -102,7 +102,7 @@ export abstract class BaseTrigger<T extends IBaseTriggerOptions> implements ITri
         if (evt.type && evt.handler) {
           if (isArray(evt.type)) {
             evt.type.forEach(evtType => {
-              evtType && evtType !== 'none' && this.options.event.on(evtType, evt.handler);
+              evtType && evtType !== 'none' && this.options.event.off(evtType, evt.handler);
             });
           } else {
             evt.type !== 'none' && this.options.event.off(evt.type, evt.handler);


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Release
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

close #4654

### 🔗 Related PR link

N/A

### 🐞 Bugserver case id

N/A

### 💡 Background and solution

`BaseTrigger.release()` supports both single event names and arrays of event names. The array branch incorrectly called `event.on` while releasing a trigger, so releasing a trigger registered the listeners again instead of removing them. This change uses `event.off` for each array entry and adds a regression test covering both event names.

The impact is limited to interaction trigger cleanup: releasing a trigger with an array-valued event no longer re-registers its listeners. There is no public API, configuration, type definition, or usage change.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix repeated trigger listeners after release. |
| 🇨🇳 Chinese | 修复触发器释放时重复注册数组事件监听器的问题。 |

A Rush patch changefile for `@visactor/vchart` has been added in commit `f3c05341a`.

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

---

### 🚀 Summary

Fix array-valued trigger event cleanup in `BaseTrigger.release()` and add the package patch changelog entry.

### 🔍 Walkthrough

- Change the release path from `event.on` to `event.off` for each array event.
- Add a unit test proving both listeners are removed without re-registering them.
- Add a Rush patch changefile for the user-visible behavior fix.
