### PR TITLE
fix: prevent rich text labels from inheriting line dash styles

### DIFF
--- a/common/changes/@visactor/vchart/fix-issue-4595-richtext-line-dash_2026-08-28.json
+++ b/common/changes/@visactor/vchart/fix-issue-4595-richtext-line-dash_2026-08-28.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@visactor/vchart",
+      "comment": "fix: prevent rich text labels from inheriting line dash styles (Issue #4595)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@visactor/vchart",
+  "email": "biukam.w@gmail.com"
+}

--- a/packages/vchart/__tests__/unit/mark/text.test.ts
+++ b/packages/vchart/__tests__/unit/mark/text.test.ts
@@ -30,6 +30,6 @@ test('rule mark initial style', () => {
   expect(stroke).toEqual(undefined);
   expect(strokeOpacity).toEqual(undefined);
   expect(strokeWidth).toEqual(0);
-  expect(lineDash).toEqual(undefined);
+  expect(lineDash).toEqual([]);
   expect(cursor).toEqual(undefined);
 });

--- a/packages/vchart/__tests__/unit/mark/text.test.ts
+++ b/packages/vchart/__tests__/unit/mark/text.test.ts
@@ -1,8 +1,10 @@
 import { markContext as ctx } from '../../util/context';
 import { TextMark } from '../../../src/mark/text';
 import { LayoutZIndex } from '../../../src/constant/layout';
+import { default as VChart } from '../../../src';
+import { createCanvas, removeDom } from '../../util/dom';
 
-test('rule mark initial style', () => {
+test('text mark initial style', () => {
   const textMark = new TextMark('rule0', ctx);
   textMark.created();
   const visible = textMark.getAttribute('visible', {});
@@ -32,4 +34,92 @@ test('rule mark initial style', () => {
   expect(strokeWidth).toEqual(0);
   expect(lineDash).toEqual([]);
   expect(cursor).toEqual(undefined);
+});
+
+describe('rich text line dash rendering', () => {
+  let canvasDom: HTMLCanvasElement;
+  let chart: VChart;
+  let setLineDashSpy: jest.SpyInstance;
+  let strokeTextSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    canvasDom = createCanvas();
+    canvasDom.width = 500;
+    canvasDom.height = 500;
+  });
+
+  afterEach(() => {
+    setLineDashSpy?.mockRestore();
+    strokeTextSpy?.mockRestore();
+    chart?.release();
+    removeDom(canvasDom);
+  });
+
+  test('resets line dash before drawing a rich text label', () => {
+    setLineDashSpy = jest.spyOn(CanvasRenderingContext2D.prototype, 'setLineDash');
+    strokeTextSpy = jest.spyOn(CanvasRenderingContext2D.prototype, 'strokeText');
+
+    chart = new VChart(
+      {
+        type: 'scatter',
+        data: [{ id: 'data1', values: [{ x: 1, y: 1, size: 50 }] }],
+        xField: 'x',
+        yField: 'y',
+        sizeField: 'size',
+        point: {
+          style: {
+            stroke: '#ff0000',
+            lineWidth: 4,
+            lineDash: [10, 10]
+          }
+        },
+        label: {
+          visible: true,
+          position: 'top',
+          offset: 10,
+          formatMethod: () => ({
+            type: 'rich',
+            text: [
+              {
+                text: 'label',
+                fontSize: 30,
+                fill: '#000',
+                stroke: '#00ff00',
+                lineWidth: 4
+              }
+            ]
+          })
+        },
+        animation: false
+      } as any,
+      {
+        renderCanvas: canvasDom,
+        animation: false
+      }
+    );
+
+    chart.renderSync();
+
+    const richTextGraphic = chart.getStage().getElementsByType('richtext')[0] as any;
+    const lineDashCalls = setLineDashSpy.mock.calls.map(([lineDash]) => lineDash);
+    const pointLineDashIndex = lineDashCalls.findIndex(
+      lineDash => Array.isArray(lineDash) && lineDash[0] === 10 && lineDash[1] === 10
+    );
+    const labelStrokeTextIndex = strokeTextSpy.mock.calls.findIndex(([text]) => text === 'label');
+    const labelStrokeTextInvocationOrder = strokeTextSpy.mock.invocationCallOrder[labelStrokeTextIndex];
+    const lineDashCallsBeforeLabel = setLineDashSpy.mock.calls
+      .map(([lineDash], index) => ({
+        lineDash,
+        invocationOrder: setLineDashSpy.mock.invocationCallOrder[index]
+      }))
+      .filter(({ invocationOrder }) => invocationOrder < labelStrokeTextInvocationOrder)
+      .sort((a, b) => a.invocationOrder - b.invocationOrder);
+    const lastLineDashBeforeLabel = lineDashCallsBeforeLabel[lineDashCallsBeforeLabel.length - 1];
+
+    expect(richTextGraphic.attribute.lineDash).toEqual([]);
+    expect(pointLineDashIndex).toBeGreaterThanOrEqual(0);
+    expect(labelStrokeTextIndex).toBeGreaterThanOrEqual(0);
+    expect(setLineDashSpy.mock.invocationCallOrder[pointLineDashIndex]).toBeLessThan(labelStrokeTextInvocationOrder);
+    expect(lastLineDashBeforeLabel?.lineDash).toEqual([]);
+  });
 });

--- a/packages/vchart/src/mark/text.ts
+++ b/packages/vchart/src/mark/text.ts
@@ -29,6 +29,7 @@ export class TextMark extends BaseMark<IComposedTextMarkSpec> implements ITextMa
       angle: 0,
       textAlign: 'center',
       lineWidth: 0,
+      lineDash: [],
       textConfig: []
     };
     return defaultStyle;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [x] Bug fix
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Refactoring
- [ ] Update dependency
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Release
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

Fixes #4595

### 🔗 Related PR link

None.

### 🐞 Bugserver case id

N/A

### 💡 Background and solution

Rich text labels could inherit a dashed `lineDash` canvas state from the graphic rendered immediately before them, so a stroked label appeared dashed even when no dash pattern was configured for the text mark.

This change gives `TextMark` an explicit empty `lineDash` default. The text mark now clears any inherited dash pattern before rich text is rendered, while an explicitly configured dash pattern remains unchanged.

The regression coverage renders a real scatter chart with a dashed point followed by a stroked rich text label. It verifies the rich text graphic receives `lineDash: []` and that the final `setLineDash` call before `strokeText('label')` resets the canvas state.

### 📝 Changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Reset the default text mark dash pattern so rich text labels do not inherit line dash styles. |
| 🇨🇳 Chinese | 重置文本图元的默认虚线配置，避免富文本标签继承前一个图元的虚线样式。 |

### ☑️ Self-Check before Merge

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed

### 🚀 Summary

Set an explicit empty dash pattern on text marks and add a rendering regression test so rich text label strokes do not inherit a preceding point's dash state.

### 🔍 Walkthrough

- Add `lineDash: []` to the default `TextMark` style.
- Rename the text mark default-style test.
- Add a real scatter rendering regression covering point dash state, rich text stroke rendering, and the reset call order.
- Add the patch change record for issue #4595.

### ✅ Verification

```text
npm test -- --runInBand __tests__/unit/mark/text.test.ts
2 tests passed

npm run compile
passed
```

The package-wide test run reached 400 passing tests; the existing `__tests__/unit/extension/pictogram-size.test.ts` suite remains blocked by unrelated `@visactor/vchart` type-resolution errors in `vchart-extension`.
